### PR TITLE
Fixing buffer allocation for adjoint MPI communication

### DIFF
--- a/braid/_braid.c
+++ b/braid/_braid.c
@@ -126,6 +126,7 @@ _braid_OptimDestroy( braid_Core core)
 
    }
 
+   free(optim->buffer);
    free(optim->adjoints);
    free(optim->tapeinput);
 
@@ -377,21 +378,24 @@ _braid_InitAdjointVars(braid_Core   core,
                        _braid_Grid *fine_grid)
 {
 
-   braid_Real       tstart   = _braid_CoreElt(core, tstart);
-   braid_App        app      = _braid_CoreElt(core, app);
-   braid_Int        storage   = _braid_CoreElt(core, storage);
-   braid_Int        ncpoints  = _braid_GridElt(fine_grid, ncpoints);
-   braid_Int        clower    = _braid_GridElt(fine_grid, clower);
-   braid_Int        iupper    = _braid_GridElt(fine_grid, iupper);
-   braid_Int        ilower    = _braid_GridElt(fine_grid, ilower);
-   braid_Int        cfactor   = _braid_GridElt(fine_grid, cfactor);
-   braid_Vector    *adjoints  = NULL; 
-   braid_VectorBar *tapeinput = NULL; 
-   braid_BaseVector u; 
-   braid_VectorBar  bar_copy;
-   braid_Vector     mybar;
-   braid_Int        ic, iclocal, sflag, nupoints, increment;
-
+   braid_Real          tstart    = _braid_CoreElt(core, tstart);
+   braid_App           app       = _braid_CoreElt(core, app);
+   braid_Int           storage   = _braid_CoreElt(core, storage);
+   braid_Int           ncpoints  = _braid_GridElt(fine_grid, ncpoints);
+   braid_Int           clower    = _braid_GridElt(fine_grid, clower);
+   braid_Int           iupper    = _braid_GridElt(fine_grid, iupper);
+   braid_Int           ilower    = _braid_GridElt(fine_grid, ilower);
+   braid_Int           cfactor   = _braid_GridElt(fine_grid, cfactor);
+   braid_BufferStatus  bstatus   = (braid_BufferStatus) core;
+   braid_Vector       *adjoints  = NULL; 
+   braid_VectorBar    *tapeinput = NULL; 
+   braid_BaseVector    u; 
+   braid_VectorBar     bar_copy;
+   braid_Vector        mybar;
+   braid_Int           ic, iclocal, sflag, nupoints, increment;
+   braid_Int           bufsize;
+   void*               buffer;
+  
 
    /* Get the number of adjoint vectors on finest level */
    if (storage < 0 ) 
@@ -449,7 +453,12 @@ _braid_InitAdjointVars(braid_Core   core,
       }
    }
 
+   /* Allocate a buffer for BufUnpackDiff*/
+   _braid_CoreFcn(core, bufsize)(app, &bufsize, bstatus);
+   buffer = malloc(bufsize); 
+
    /* Pass to the optimization structure */
+   _braid_CoreElt(core, optim)->buffer    = buffer;
    _braid_CoreElt(core, optim)->adjoints  = adjoints;
    _braid_CoreElt(core, optim)->tapeinput = tapeinput;
 

--- a/braid/_braid.c
+++ b/braid/_braid.c
@@ -127,7 +127,6 @@ _braid_OptimDestroy( braid_Core core)
    }
 
    free(optim->sendbuffer);
-   free(optim->recvbuffer);
    free(optim->adjoints);
    free(optim->tapeinput);
 
@@ -396,7 +395,6 @@ _braid_InitAdjointVars(braid_Core   core,
    braid_Int           ic, iclocal, sflag, nupoints, increment;
    braid_Int           bufsize;
    void*               sendbuffer;
-   void*               recvbuffer;
   
 
    /* Get the number of adjoint vectors on finest level */
@@ -458,11 +456,9 @@ _braid_InitAdjointVars(braid_Core   core,
    /* Allocate a buffer for BufUnpackDiff*/
    _braid_CoreFcn(core, bufsize)(app, &bufsize, bstatus);
    sendbuffer = malloc(bufsize); 
-   recvbuffer = malloc(bufsize); 
 
    /* Pass to the optimization structure */
    _braid_CoreElt(core, optim)->sendbuffer = sendbuffer;
-   _braid_CoreElt(core, optim)->recvbuffer = recvbuffer;
    _braid_CoreElt(core, optim)->adjoints   = adjoints;
    _braid_CoreElt(core, optim)->tapeinput  = tapeinput;
 

--- a/braid/_braid.c
+++ b/braid/_braid.c
@@ -126,7 +126,8 @@ _braid_OptimDestroy( braid_Core core)
 
    }
 
-   free(optim->buffer);
+   free(optim->sendbuffer);
+   free(optim->recvbuffer);
    free(optim->adjoints);
    free(optim->tapeinput);
 
@@ -394,7 +395,8 @@ _braid_InitAdjointVars(braid_Core   core,
    braid_Vector        mybar;
    braid_Int           ic, iclocal, sflag, nupoints, increment;
    braid_Int           bufsize;
-   void*               buffer;
+   void*               sendbuffer;
+   void*               recvbuffer;
   
 
    /* Get the number of adjoint vectors on finest level */
@@ -455,12 +457,14 @@ _braid_InitAdjointVars(braid_Core   core,
 
    /* Allocate a buffer for BufUnpackDiff*/
    _braid_CoreFcn(core, bufsize)(app, &bufsize, bstatus);
-   buffer = malloc(bufsize); 
+   sendbuffer = malloc(bufsize); 
+   recvbuffer = malloc(bufsize); 
 
    /* Pass to the optimization structure */
-   _braid_CoreElt(core, optim)->buffer    = buffer;
-   _braid_CoreElt(core, optim)->adjoints  = adjoints;
-   _braid_CoreElt(core, optim)->tapeinput = tapeinput;
+   _braid_CoreElt(core, optim)->sendbuffer = sendbuffer;
+   _braid_CoreElt(core, optim)->recvbuffer = recvbuffer;
+   _braid_CoreElt(core, optim)->adjoints   = adjoints;
+   _braid_CoreElt(core, optim)->tapeinput  = tapeinput;
 
    return _braid_error_flag;
 }                

--- a/braid/_braid.c
+++ b/braid/_braid.c
@@ -461,9 +461,9 @@ _braid_InitAdjointVars(braid_Core   core,
 
    /* Pass to the optimization structure */
    _braid_CoreElt(core, optim)->sendbuffer = sendbuffer;
-   _braid_CoreElt(core, optim)->request= request;
-   _braid_CoreElt(core, optim)->adjoints   = adjoints;
-   _braid_CoreElt(core, optim)->tapeinput  = tapeinput;
+   _braid_CoreElt(core, optim)->request    = request;
+   _braid_CoreElt(core, optim)->adjoints  = adjoints;
+   _braid_CoreElt(core, optim)->tapeinput = tapeinput;
 
    return _braid_error_flag;
 }                

--- a/braid/_braid.c
+++ b/braid/_braid.c
@@ -395,6 +395,7 @@ _braid_InitAdjointVars(braid_Core   core,
    braid_Int           ic, iclocal, sflag, nupoints, increment;
    braid_Int           bufsize;
    void*               sendbuffer;
+   MPI_Request*        request;
   
 
    /* Get the number of adjoint vectors on finest level */
@@ -456,9 +457,11 @@ _braid_InitAdjointVars(braid_Core   core,
    /* Allocate a buffer for BufUnpackDiff*/
    _braid_CoreFcn(core, bufsize)(app, &bufsize, bstatus);
    sendbuffer = malloc(bufsize*sizeof(double)); 
+   request = NULL;
 
    /* Pass to the optimization structure */
    _braid_CoreElt(core, optim)->sendbuffer = sendbuffer;
+   _braid_CoreElt(core, optim)->request= request;
    _braid_CoreElt(core, optim)->adjoints   = adjoints;
    _braid_CoreElt(core, optim)->tapeinput  = tapeinput;
 

--- a/braid/_braid.c
+++ b/braid/_braid.c
@@ -455,7 +455,7 @@ _braid_InitAdjointVars(braid_Core   core,
 
    /* Allocate a buffer for BufUnpackDiff*/
    _braid_CoreFcn(core, bufsize)(app, &bufsize, bstatus);
-   sendbuffer = malloc(bufsize); 
+   sendbuffer = malloc(bufsize*sizeof(double)); 
 
    /* Pass to the optimization structure */
    _braid_CoreElt(core, optim)->sendbuffer = sendbuffer;

--- a/braid/_braid.c
+++ b/braid/_braid.c
@@ -456,7 +456,7 @@ _braid_InitAdjointVars(braid_Core   core,
 
    /* Allocate a buffer for BufUnpackDiff*/
    _braid_CoreFcn(core, bufsize)(app, &bufsize, bstatus);
-   sendbuffer = malloc(bufsize*sizeof(double)); 
+   sendbuffer = malloc(bufsize); 
    request = NULL;
 
    /* Pass to the optimization structure */

--- a/braid/_braid.h
+++ b/braid/_braid.h
@@ -104,6 +104,7 @@ struct _braid_Optimization_struct
    braid_Int        rtol_adj;         /**< flag: use relative tolerance for adjoint */
    braid_Vector    *adjoints;         /**< vector for the adjoint variables */
    braid_VectorBar *tapeinput;        /**< helper: store pointer to input of one braid iteration */
+   void            *buffer;           /**< helper: Memory for BufUnPackDiff communication */
 };
 typedef struct _braid_Optimization_struct *braid_Optim;
 

--- a/braid/_braid.h
+++ b/braid/_braid.h
@@ -105,7 +105,7 @@ struct _braid_Optimization_struct
    braid_Vector    *adjoints;         /**< vector for the adjoint variables */
    braid_VectorBar *tapeinput;        /**< helper: store pointer to input of one braid iteration */
    void            *sendbuffer;       /**< helper: Memory for BufUnPackDiff communication */
-   MPI_Request     *request;         
+   MPI_Request     *request;          /**< helper: Storing the MPI request of BufUnPackDiff */
 };
 typedef struct _braid_Optimization_struct *braid_Optim;
 

--- a/braid/_braid.h
+++ b/braid/_braid.h
@@ -105,6 +105,7 @@ struct _braid_Optimization_struct
    braid_Vector    *adjoints;         /**< vector for the adjoint variables */
    braid_VectorBar *tapeinput;        /**< helper: store pointer to input of one braid iteration */
    void            *sendbuffer;       /**< helper: Memory for BufUnPackDiff communication */
+   MPI_Request     *request;         
 };
 typedef struct _braid_Optimization_struct *braid_Optim;
 

--- a/braid/_braid.h
+++ b/braid/_braid.h
@@ -105,7 +105,6 @@ struct _braid_Optimization_struct
    braid_Vector    *adjoints;         /**< vector for the adjoint variables */
    braid_VectorBar *tapeinput;        /**< helper: store pointer to input of one braid iteration */
    void            *sendbuffer;       /**< helper: Memory for BufUnPackDiff communication */
-   void            *recvbuffer;       /**< helper: Memory for BufPackDiff communication */
 };
 typedef struct _braid_Optimization_struct *braid_Optim;
 

--- a/braid/_braid.h
+++ b/braid/_braid.h
@@ -104,7 +104,8 @@ struct _braid_Optimization_struct
    braid_Int        rtol_adj;         /**< flag: use relative tolerance for adjoint */
    braid_Vector    *adjoints;         /**< vector for the adjoint variables */
    braid_VectorBar *tapeinput;        /**< helper: store pointer to input of one braid iteration */
-   void            *buffer;           /**< helper: Memory for BufUnPackDiff communication */
+   void            *sendbuffer;       /**< helper: Memory for BufUnPackDiff communication */
+   void            *recvbuffer;       /**< helper: Memory for BufPackDiff communication */
 };
 typedef struct _braid_Optimization_struct *braid_Optim;
 

--- a/braid/_braid_base.c
+++ b/braid/_braid_base.c
@@ -862,9 +862,9 @@ _braid_BaseBufPack_diff(_braid_Action *action )
    ubar = (braid_VectorBar) (_braid_CoreElt(core, barTape)->data_ptr);
    _braid_CoreElt(core, barTape) = _braid_TapePop( _braid_CoreElt(core, barTape) );
 
-   /* Allocate the buffer */
+   /* Get the buffer */
    _braid_CoreFcn(core, bufsize)(app, &size, bstatus);
-   buffer = malloc(size);
+   buffer = _braid_CoreElt(core, optim)->buffer;
 
    /* Receive the buffer */
    MPI_Recv(buffer, size, MPI_BYTE, send_recv_rank, 0, _braid_CoreElt(core, comm), MPI_STATUS_IGNORE); 
@@ -881,7 +881,6 @@ _braid_BaseBufPack_diff(_braid_Action *action )
    /* Free the vectors */
    _braid_VectorBarDelete(core, ubar);
    _braid_CoreFcn(core, free)(app, u);
-   free(buffer);
 
    return _braid_error_flag;
 }
@@ -908,9 +907,9 @@ _braid_BaseBufUnpack_diff(_braid_Action *action)
    ubar = (braid_VectorBar) (_braid_CoreElt(core, barTape)->data_ptr);
    _braid_CoreElt(core, barTape) = _braid_TapePop( _braid_CoreElt(core, barTape) );
 
-  /* Allocate buffer */
+   /* Get the buffer */
    _braid_CoreFcn(core, bufsize)(app, &size, bstatus);
-   buffer = malloc(size); 
+   buffer = _braid_CoreElt(core, optim)->buffer;
 
    /* Initialize the bufferstatus */
    _braid_BufferStatusInit( messagetype, size_buffer, bstatus);

--- a/braid/_braid_base.c
+++ b/braid/_braid_base.c
@@ -929,7 +929,7 @@ _braid_BaseBufUnpack_diff(_braid_Action *action)
    /* Send the buffer  */
    requests = _braid_CTAlloc(MPI_Request, 1);
    MPI_Isend(sendbuffer, size, MPI_BYTE, send_recv_rank, 0, _braid_CoreElt(core, comm), &requests[0]);
-   request = requests;
+   _braid_CoreElt(core, optim)->request = requests;
    
    /* Set ubar to zero */
    _braid_CoreFcn(core, sum)(app, -1., ubar->userVector, 1., ubar->userVector );

--- a/braid/_braid_base.c
+++ b/braid/_braid_base.c
@@ -844,7 +844,7 @@ braid_Int
 _braid_BaseBufPack_diff(_braid_Action *action )
 {
    braid_Int          size;
-   void              *recvbuffer;
+   void              *buffer;
    braid_Vector       u;
    braid_VectorBar    ubar;
    braid_Core         core            = action->core;
@@ -864,16 +864,17 @@ _braid_BaseBufPack_diff(_braid_Action *action )
 
    /* Get the buffer */
    _braid_CoreFcn(core, bufsize)(app, &size, bstatus);
-   recvbuffer = _braid_CoreElt(core, optim)->recvbuffer;
+   buffer = malloc(size);
 
    /* Receive the buffer */
-   MPI_Recv(recvbuffer, size, MPI_BYTE, send_recv_rank, 0, _braid_CoreElt(core, comm), MPI_STATUS_IGNORE); 
+   MPI_Recv(buffer, size, MPI_BYTE, send_recv_rank, 0, _braid_CoreElt(core, comm), MPI_STATUS_IGNORE); 
 
    /* Initialize the bstatus */
    _braid_BufferStatusInit( messagetype, size_buffer, bstatus);
 
    /* Unpack the buffer into u */
-   _braid_CoreFcn(core, bufunpack)(app, recvbuffer, &u, bstatus);
+   _braid_CoreFcn(core, bufunpack)(app, buffer, &u, bstatus);
+   free(buffer);
 
    /* Update ubar with u */
    _braid_CoreFcn(core, sum)( app, 1., u, 1., ubar->userVector);

--- a/braid/_braid_base.c
+++ b/braid/_braid_base.c
@@ -910,18 +910,26 @@ _braid_BaseBufUnpack_diff(_braid_Action *action)
 
    /* Get the buffer */
    _braid_CoreFcn(core, bufsize)(app, &size, bstatus);
-   sendbuffer = _braid_CoreElt(core, optim)->sendbuffer;
+
+  /* Wait */
+   MPI_Request *request = _braid_CoreElt(core, optim)->request;
+   MPI_Status *mpistatus = malloc(sizeof(MPI_Status));
+   if (request != NULL)
+   {
+     MPI_Wait(request, mpistatus);
+   }
 
    /* Initialize the bufferstatus */
    _braid_BufferStatusInit( messagetype, size_buffer, bstatus);
 
    /* Pack the buffer */
+   sendbuffer = _braid_CoreElt(core, optim)->sendbuffer;
    _braid_CoreFcn(core, bufpack)( app, ubar->userVector, sendbuffer, bstatus);
 
    /* Send the buffer  */
    requests = _braid_CTAlloc(MPI_Request, 1);
    MPI_Isend(sendbuffer, size, MPI_BYTE, send_recv_rank, 0, _braid_CoreElt(core, comm), &requests[0]);
-   MPI_Request_free(requests);
+   request = requests;
    
    /* Set ubar to zero */
    _braid_CoreFcn(core, sum)(app, -1., ubar->userVector, 1., ubar->userVector );

--- a/braid/braid.c
+++ b/braid/braid.c
@@ -967,6 +967,7 @@ braid_InitAdjoint(braid_PtFcnObjectiveT        objectiveT,
    /* Set optimization variables */
    optim->adjoints       = NULL;    /* will be allocated in InitAdjointVars() */
    optim->tapeinput      = NULL;    /* will be allocated in InitAdjointVars() */   
+   optim->buffer         = NULL;    /* will be allocated in InitAdjointVars() */   
    optim->objective      = 0.0;
    optim->sum_user_obj   = 0.0;
    optim->f_bar          = 0.0;

--- a/braid/braid.c
+++ b/braid/braid.c
@@ -967,7 +967,8 @@ braid_InitAdjoint(braid_PtFcnObjectiveT        objectiveT,
    /* Set optimization variables */
    optim->adjoints       = NULL;    /* will be allocated in InitAdjointVars() */
    optim->tapeinput      = NULL;    /* will be allocated in InitAdjointVars() */   
-   optim->buffer         = NULL;    /* will be allocated in InitAdjointVars() */   
+   optim->sendbuffer     = NULL;    /* will be allocated in InitAdjointVars() */   
+   optim->recvbuffer     = NULL;    /* will be allocated in InitAdjointVars() */   
    optim->objective      = 0.0;
    optim->sum_user_obj   = 0.0;
    optim->f_bar          = 0.0;

--- a/braid/braid.c
+++ b/braid/braid.c
@@ -968,6 +968,7 @@ braid_InitAdjoint(braid_PtFcnObjectiveT        objectiveT,
    optim->adjoints       = NULL;    /* will be allocated in InitAdjointVars() */
    optim->tapeinput      = NULL;    /* will be allocated in InitAdjointVars() */   
    optim->sendbuffer     = NULL;    /* will be allocated in InitAdjointVars() */   
+   optim->request        = NULL;    /* will be allocated in InitAdjointVars() */   
    optim->objective      = 0.0;
    optim->sum_user_obj   = 0.0;
    optim->f_bar          = 0.0;

--- a/braid/braid.c
+++ b/braid/braid.c
@@ -968,7 +968,6 @@ braid_InitAdjoint(braid_PtFcnObjectiveT        objectiveT,
    optim->adjoints       = NULL;    /* will be allocated in InitAdjointVars() */
    optim->tapeinput      = NULL;    /* will be allocated in InitAdjointVars() */   
    optim->sendbuffer     = NULL;    /* will be allocated in InitAdjointVars() */   
-   optim->recvbuffer     = NULL;    /* will be allocated in InitAdjointVars() */   
    optim->objective      = 0.0;
    optim->sum_user_obj   = 0.0;
    optim->f_bar          = 0.0;


### PR DESCRIPTION
Store the sendbuffer and request for adjoint MPI_Isend in the optim structure. Call MPI_Wait() within BufUnpack_diff before another ISend is initiated. 