### PR TITLE
Fortran interface: add braid_SetPrintFile

### DIFF
--- a/braid/braid_F90_iface.c
+++ b/braid/braid_F90_iface.c
@@ -1115,7 +1115,13 @@ braid_F90_Name(braid_set_print_level_f90, BRAID_SET_PRINT_LEVEL_F90)(
    return 0;
 }
 
-/* braid_SetPrintFile( ) */
+/* braid_SetPrintFile( )
+ *
+ * User advice: Null-terminate the string fname in your Fortran code, e.g.,
+ * if braidLogFile is of type character(len=128) and braid_spacetime_rank is of type integer:
+ *
+ * write(braidLogFile, "('braid_log.',I0.12,A)") braid_spacetime_rank, char(0)
+*/
 braid_Int
 braid_F90_Name(braid_set_print_file_f90, BRAID_SET_PRINT_FILE_F90)(
                    braid_F90_ObjPtr  *core,          /**< braid_Core (_braid_Core) struct*/

--- a/braid/braid_F90_iface.c
+++ b/braid/braid_F90_iface.c
@@ -1115,6 +1115,19 @@ braid_F90_Name(braid_set_print_level_f90, BRAID_SET_PRINT_LEVEL_F90)(
    return 0;
 }
 
+/* braid_SetPrintFile( ) */
+braid_Int
+braid_F90_Name(braid_set_print_file_f90, BRAID_SET_PRINT_FILE_F90)(
+                   braid_F90_ObjPtr  *core,          /**< braid_Core (_braid_Core) struct*/
+                   char              *fname,         /**< name of string to set */
+                   braid_F90_Int     *ll             /**< string length */
+                   )
+{
+   braid_SetPrintFile(braid_TakeF90_ObjDeref(braid_Core,  core),
+                                                          fname);
+   return 0;
+}
+
 /* braid_SetDefaultPrintFile( ) */
 braid_Int
 braid_F90_Name(braid_set_default_print_file_f90, braid_set_default_print_file_F90)(


### PR DESCRIPTION
This commit adds the ability to set the log file name from Fortran code by exposing the C-function in the Fortran interface.