### PR TITLE
Added sequential initialization after refinement if seq_soln is true

### DIFF
--- a/braid/_braid.c
+++ b/braid/_braid.c
@@ -1777,6 +1777,7 @@ _braid_InitGuess(braid_Core  core,
 {
    braid_App          app      = _braid_CoreElt(core, app);
    braid_Int          seq_soln = _braid_CoreElt(core, seq_soln);
+   braid_Int          nrefine  = _braid_CoreElt(core,nrefine);
    _braid_Grid      **grids    = _braid_CoreElt(core, grids);
    braid_Int          ilower   = _braid_GridElt(grids[level], ilower);
    braid_Int          iupper   = _braid_GridElt(grids[level], iupper);
@@ -1794,8 +1795,16 @@ _braid_InitGuess(braid_Core  core,
       /* If first processor, grab initial condition */
       if(ilower == 0)
       {
-         _braid_BaseInit(core, app,  ta[0], &u);
-         _braid_USetVector(core, 0, 0, u, 0);
+         /* If we have already refined, then an initial init has already been done */
+         if(nrefine > 0)
+         {
+            _braid_UGetVector(core, 0, 0, &u);    /* Get stored vector */
+         }
+         else
+         {
+            _braid_BaseInit(core, app,  ta[0], &u);
+            _braid_USetVector(core, 0, 0, u, 0);
+         }
          ilower += 1;
       }
       /* Else, receive point to the left */

--- a/braid/braid.c
+++ b/braid/braid.c
@@ -459,6 +459,7 @@ braid_Drive(braid_Core  core)
    braid_PtFcnResidual  fullres         = _braid_CoreElt(core, full_rnorm_res);
    braid_Int            obj_only        = _braid_CoreElt(core, obj_only);
    braid_Int            adjoint         = _braid_CoreElt(core, adjoint);
+   braid_Int            seq_soln        = _braid_CoreElt(core, seq_soln);
 
 
    braid_Int     *nrels, nrel0;
@@ -670,6 +671,14 @@ braid_Drive(braid_Core  core)
             /* Finest grid - refine grid if desired */
             _braid_FRefine(core, &refined);
             nlevels = _braid_CoreElt(core, nlevels);
+
+            // If we are done refining and doing a fixed point test,
+            // then compute the sequential solution on the finest grid
+            braid_Int rstopped = _braid_CoreElt(core, rstopped);
+            if( (rstopped > -1) && (rstopped == iter) && (seq_soln == 1) )
+            {
+               _braid_InitGuess(core, 0);
+            }
 
             if ( adjoint )
             {


### PR DESCRIPTION
If sequential initialization is to be used, perform the sequential initialization on the finest level after the final refinement.

This does a little bit of extra work, as sequential initialization is done on level 0 before any refinement or coarsening is done.