### PR TITLE
Max levels after refinement

### DIFF
--- a/braid/_braid.c
+++ b/braid/_braid.c
@@ -3213,6 +3213,13 @@ _braid_FRefine(braid_Core   core,
    /* Initialize new hierarchy */
    _braid_CoreElt(core, gupper)  = f_gupper;
    _braid_CoreElt(core, nrefine) += 1;
+   braid_Int newrefine = _braid_CoreElt(core, nrefine);
+   // If we have hit max refinement, then limit the max levels
+   if(!(newrefine < max_refinements))
+   {
+      braid_Int maxLevelAfterRefine = _braid_CoreElt(core, max_levels_after_refine);
+      braid_SetMaxLevels(core, maxLevelAfterRefine);
+   }
    /*braid_SetCFactor(core,  0, cfactor);*/ /* RDF HACKED TEST */
    _braid_InitHierarchy(core, f_grid, 1);
 

--- a/braid/_braid.c
+++ b/braid/_braid.c
@@ -3213,9 +3213,9 @@ _braid_FRefine(braid_Core   core,
    /* Initialize new hierarchy */
    _braid_CoreElt(core, gupper)  = f_gupper;
    _braid_CoreElt(core, nrefine) += 1;
-   braid_Int newrefine = _braid_CoreElt(core, nrefine);
+   braid_Int numrefine = _braid_CoreElt(core, nrefine);
    // If we have hit max refinement, then limit the max levels
-   if(!(newrefine < max_refinements))
+   if(!(numrefine < max_refinements) || (f_gupper >= tpoints_cutoff))
    {
       braid_Int maxLevelAfterRefine = _braid_CoreElt(core, max_levels_after_refine);
       braid_SetMaxLevels(core, maxLevelAfterRefine);

--- a/braid/_braid.c
+++ b/braid/_braid.c
@@ -3529,7 +3529,7 @@ _braid_InitHierarchy(braid_Core    core,
       else
       {
          /* This is the coarsest level */
-         if ( (level > 0) || (!refined) )
+         if ( (level > 0) || (!refined) || (max_levels <= 1) )
          {
             /* If this is a true coarse level (it has a fine grid above it in
              * the current hierarchy) or it is a fine level that was not built

--- a/braid/_braid.h
+++ b/braid/_braid.h
@@ -205,6 +205,7 @@ typedef struct _braid_Core_struct
    braid_Int              io_level;         /**< determines amount of output printed to files (0,1) */
    braid_Int              seq_soln;         /**< boolean, controls if the initial guess is from sequential time stepping*/
    braid_Int              max_levels;       /**< maximum number of temporal grid levels */
+   braid_Int              max_levels_after_refine; /**< maximum number of temporal grid levels after refinement */
    braid_Int              min_coarse;       /**< minimum possible coarse grid size */
    braid_Real             tol;              /**< stopping tolerance */
    braid_Int              rtol;             /**< use relative tolerance */

--- a/braid/braid.c
+++ b/braid/braid.c
@@ -881,7 +881,7 @@ braid_Init(MPI_Comm               comm_world,
    _braid_CoreElt(core, print_level)     = print_level;
    _braid_CoreElt(core, io_level)        = io_level;
    _braid_CoreElt(core, max_levels)      = 0; /* Set with SetMaxLevels() below */
-   _braid_CoreElt(core, max_levels_after_refine) = 0; /* Set with SetMaxLevels() below */
+   _braid_CoreElt(core, max_levels_after_refine) = max_levels_after_refine;
    _braid_CoreElt(core, min_coarse)      = min_coarse;
    _braid_CoreElt(core, seq_soln)        = seq_soln;
    _braid_CoreElt(core, tol)             = tol;

--- a/braid/braid.c
+++ b/braid/braid.c
@@ -824,6 +824,7 @@ braid_Init(MPI_Comm               comm_world,
    braid_Int              nfmg_Vcyc       = 1;              /* Default num V-cycles at each fmg level is 1 */
    braid_Int              max_iter        = 100;            /* Default max_iter */
    braid_Int              max_levels      = 30;             /* Default max_levels */
+   braid_Int              max_levels_after_refine = 30;     /* Default max_levels_after_refine */
    braid_Int              min_coarse      = 2;              /* Default min_coarse */
    braid_Int              seq_soln        = 0;              /* Default initial guess is from user's Init() function */
    braid_Int              print_level     = 2;              /* Default print level */
@@ -880,6 +881,7 @@ braid_Init(MPI_Comm               comm_world,
    _braid_CoreElt(core, print_level)     = print_level;
    _braid_CoreElt(core, io_level)        = io_level;
    _braid_CoreElt(core, max_levels)      = 0; /* Set with SetMaxLevels() below */
+   _braid_CoreElt(core, max_levels_after_refine) = 0; /* Set with SetMaxLevels() below */
    _braid_CoreElt(core, min_coarse)      = min_coarse;
    _braid_CoreElt(core, seq_soln)        = seq_soln;
    _braid_CoreElt(core, tol)             = tol;
@@ -1221,6 +1223,17 @@ braid_SetMaxLevels(braid_Core  core,
    _braid_CoreElt(core, cfactors) = cfactors;
    _braid_CoreElt(core, grids)    = grids;
 
+   return _braid_error_flag;
+}
+
+/*--------------------------------------------------------------------------
+ *--------------------------------------------------------------------------*/
+
+braid_Int
+braid_SetMaxLevelsAfterRefine(braid_Core  core,
+                              braid_Int   max_levels_after_refine)
+{
+   _braid_CoreElt(core, max_levels_after_refine) = max_levels_after_refine;
    return _braid_error_flag;
 }
 

--- a/braid/braid.h
+++ b/braid/braid.h
@@ -538,6 +538,15 @@ braid_SetMaxLevels(braid_Core  core,        /**< braid_Core (_braid_Core) struct
                    );
 
 /**
+ * Set max number of multigrid levels after refinements have finished. Defaults to
+ * max levels. Value must be less than max levels.
+ **/
+braid_Int
+braid_SetMaxLevelsAfterRefine(braid_Core  core,                   /**< braid_Core (_braid_Core) struct*/
+                              braid_Int   max_levels_after_refine /**< maximum levels to allow after refinement */
+                              );
+
+/**
  * Set whether to skip all work on the first down cycle (skip = 1).  On by default.
  **/
 braid_Int

--- a/braid/braid.hpp
+++ b/braid/braid.hpp
@@ -431,7 +431,10 @@ public:
    }
 
    void SetMaxLevels(braid_Int max_levels) { braid_SetMaxLevels(core, max_levels); }
-   
+
+   void SetMaxLevelsAfterRefine(braid_Int max_levels_after_refine)
+   { braid_SetMaxLevelsAfterRefine(core, max_levels_after_refine); }
+
    void SetSkip(braid_Int skip) { braid_SetSkip(core, skip); }
 
    void SetMinCoarse(braid_Int min_coarse) { braid_SetMinCoarse(core, min_coarse); }

--- a/braid/braid_F90_iface.c
+++ b/braid/braid_F90_iface.c
@@ -901,6 +901,18 @@ braid_F90_Name(braid_set_max_levels_f90, BRAID_SET_MAX_LEVELS_F90)(
    return 0;
 }
 
+/*  braid_SetMaxLevelsAfterRefine( ) */
+braid_Int
+braid_F90_Name(braid_set_max_levels_after_refine_f90, BRAID_SET_MAX_LEVELS_AFTER_REFINE_F90)(
+   braid_F90_ObjPtr  *core,                   /**< braid_Core (_braid_Core) struct*/
+   braid_F90_Int     *max_levels_after_refine /**< maximum levels to allow after refinement */
+   )
+{
+   braid_SetMaxLevels(braid_TakeF90_ObjDeref(braid_Core,  core) ,
+                      braid_TakeF90_Int(                  max_levels_after_refine) );
+   return 0;
+}
+
 /*  braid_SetSkip( ) */
 braid_Int
 braid_F90_Name(braid_set_skip_f90, BRAID_SET_SKIP_F90)(


### PR DESCRIPTION
This is an initial implementation of setting a maximum number of levels after refinement. It definitely needs a bit more development before merging, namely with the detecting when we have reached maximum refinement. This is currently in a "works for my use case" state.

The new temporal grid hierarchy is initialized at the end of FRefine. At that point in the algorithm, the only criteria we have available to check against is max_refine and tpoints_cutoff. I think it would be ideal to also check after an FCRelax to see if any more refinement was requested by the user, but that would require another InitHierarchy call.