### PR TITLE
Feature increase max level after refine

### DIFF
--- a/braid/_braid.c
+++ b/braid/_braid.c
@@ -3213,6 +3213,15 @@ _braid_FRefine(braid_Core   core,
    /* Initialize new hierarchy */
    _braid_CoreElt(core, gupper)  = f_gupper;
    _braid_CoreElt(core, nrefine) += 1;
+
+   braid_Int incr_max_levels = _braid_CoreElt(core, incr_max_levels);
+   if(incr_max_levels == 1)
+   {
+      braid_Int new_max_levels = _braid_CoreElt(core, max_levels);
+      ++new_max_levels;
+      _braid_CoreElt(core, max_levels) = new_max_levels;
+   }
+
    /*braid_SetCFactor(core,  0, cfactor);*/ /* RDF HACKED TEST */
    _braid_InitHierarchy(core, f_grid, 1);
 

--- a/braid/_braid.h
+++ b/braid/_braid.h
@@ -205,6 +205,7 @@ typedef struct _braid_Core_struct
    braid_Int              io_level;         /**< determines amount of output printed to files (0,1) */
    braid_Int              seq_soln;         /**< boolean, controls if the initial guess is from sequential time stepping*/
    braid_Int              max_levels;       /**< maximum number of temporal grid levels */
+   braid_Int              incr_max_levels;  /**< After doing refinement, increase the max number of levels by 1 (0=false, 1=true)*/
    braid_Int              min_coarse;       /**< minimum possible coarse grid size */
    braid_Real             tol;              /**< stopping tolerance */
    braid_Int              rtol;             /**< use relative tolerance */

--- a/braid/braid.c
+++ b/braid/braid.c
@@ -452,6 +452,7 @@ braid_Drive(braid_Core  core)
    braid_Int            ntime           = _braid_CoreElt(core, ntime);
    braid_Int            skip            = _braid_CoreElt(core, skip);
    braid_Int            max_levels      = _braid_CoreElt(core, max_levels);
+   braid_Int            incr_max_levels = _braid_CoreElt(core, incr_max_levels);
    braid_Int            warm_restart    = _braid_CoreElt(core, warm_restart);
    braid_Int            print_level     = _braid_CoreElt(core, print_level);
    braid_Int            access_level    = _braid_CoreElt(core, access_level);
@@ -574,7 +575,7 @@ braid_Drive(braid_Core  core)
    
    nlevels = _braid_CoreElt(core, nlevels);
    done  = 0;
-   if (max_levels <= 1)
+   if (max_levels <= 1 && incr_max_levels == 0)
    {
       /* Just do sequential time marching */
       done = 1;

--- a/braid/braid.c
+++ b/braid/braid.c
@@ -824,6 +824,7 @@ braid_Init(MPI_Comm               comm_world,
    braid_Int              nfmg_Vcyc       = 1;              /* Default num V-cycles at each fmg level is 1 */
    braid_Int              max_iter        = 100;            /* Default max_iter */
    braid_Int              max_levels      = 30;             /* Default max_levels */
+   braid_Int              incr_max_levels = 0;              /* Default increment max levels is false */
    braid_Int              min_coarse      = 2;              /* Default min_coarse */
    braid_Int              seq_soln        = 0;              /* Default initial guess is from user's Init() function */
    braid_Int              print_level     = 2;              /* Default print level */
@@ -880,6 +881,7 @@ braid_Init(MPI_Comm               comm_world,
    _braid_CoreElt(core, print_level)     = print_level;
    _braid_CoreElt(core, io_level)        = io_level;
    _braid_CoreElt(core, max_levels)      = 0; /* Set with SetMaxLevels() below */
+   _braid_CoreElt(core, incr_max_levels) = incr_max_levels;
    _braid_CoreElt(core, min_coarse)      = min_coarse;
    _braid_CoreElt(core, seq_soln)        = seq_soln;
    _braid_CoreElt(core, tol)             = tol;
@@ -1220,6 +1222,18 @@ braid_SetMaxLevels(braid_Core  core,
    _braid_CoreElt(core, nrels)    = nrels;
    _braid_CoreElt(core, cfactors) = cfactors;
    _braid_CoreElt(core, grids)    = grids;
+
+   return _braid_error_flag;
+}
+
+/*--------------------------------------------------------------------------
+ *--------------------------------------------------------------------------*/
+
+braid_Int
+braid_SetIncrMaxLevels(braid_Core  core,
+                       braid_Int   incr_max_levels)
+{
+   _braid_CoreElt(core, incr_max_levels) = incr_max_levels;
 
    return _braid_error_flag;
 }

--- a/braid/braid.h
+++ b/braid/braid.h
@@ -536,6 +536,13 @@ braid_Int
 braid_SetMaxLevels(braid_Core  core,        /**< braid_Core (_braid_Core) struct*/
                    braid_Int   max_levels   /**< maximum levels to allow */
                    );
+/**
+ * Increase the max number of multigrid levels after performing a refinement.
+ **/
+braid_Int
+braid_SetIncrMaxLevels(braid_Core  core,
+                       braid_Int   incr_max_levels
+                       );
 
 /**
  * Set whether to skip all work on the first down cycle (skip = 1).  On by default.

--- a/braid/braid.hpp
+++ b/braid/braid.hpp
@@ -431,7 +431,9 @@ public:
    }
 
    void SetMaxLevels(braid_Int max_levels) { braid_SetMaxLevels(core, max_levels); }
-   
+
+   void SetIncrMaxLevels(braid_Int incr_max_levels) { braid_SetIncrMaxLevels(core, incr_max_levels); }
+
    void SetSkip(braid_Int skip) { braid_SetSkip(core, skip); }
 
    void SetMinCoarse(braid_Int min_coarse) { braid_SetMinCoarse(core, min_coarse); }

--- a/braid/braid_F90_iface.c
+++ b/braid/braid_F90_iface.c
@@ -901,6 +901,18 @@ braid_F90_Name(braid_set_max_levels_f90, BRAID_SET_MAX_LEVELS_F90)(
    return 0;
 }
 
+/*  braid_SetIncrMaxLevels( ) */
+braid_Int
+braid_F90_Name(braid_set_incr_max_levels_f90, BRAID_SET_INCR_MAX_LEVELS_F90)(
+   braid_F90_ObjPtr  *core,        /**< braid_Core (_braid_Core) struct*/
+   braid_F90_Int     *incr_max_levels   /**< increment max levels after refinement */
+   )
+{
+   braid_SetIncrMaxLevels(braid_TakeF90_ObjDeref(braid_Core,  core) ,
+                          braid_TakeF90_Int(                  incr_max_levels) );
+   return 0;
+}
+
 /*  braid_SetSkip( ) */
 braid_Int
 braid_F90_Name(braid_set_skip_f90, BRAID_SET_SKIP_F90)(


### PR DESCRIPTION
Adds an option to allow increasing the maximum number of levels after performing a temporal refinement. This is done before FRefine does its InitHierarchy so that we can generate a max_level+1 multigrid hierarchy.