### PR TITLE
Added calling function to C++ interface

### DIFF
--- a/braid/braid.hpp
+++ b/braid/braid.hpp
@@ -195,6 +195,10 @@ class BraidAccessStatus
       void GetWrapperTest(braid_Int *wtest_ptr) { braid_AccessStatusGetWrapperTest(astatus, wtest_ptr); }
       void GetResidual(braid_Real *rnorm_ptr)   { braid_AccessStatusGetResidual(astatus, rnorm_ptr); }
       void GetNRefine(braid_Int *nrefine_ptr)   { braid_AccessStatusGetNRefine(astatus, nrefine_ptr); }
+      void GetCallingFunction(braid_Int *callingfcn_ptr)
+      {
+         braid_AccessStatusGetCallingFunction(astatus, callingfcn_ptr);
+      }
 
       // The braid_AccessStatus structure is deallocated inside of Braid
       // This class is just to make code consistently look object oriented


### PR DESCRIPTION
In the C++ interface, BraidAccessStatus did not have a way to get the calling function from the AccessStatus struct. This adds that functionality.