### PR TITLE
Interface routine for printing convergence history to a file

### DIFF
--- a/braid/braid.c
+++ b/braid/braid.c
@@ -1197,7 +1197,7 @@ braid_PrintStats(braid_Core  core)
  *--------------------------------------------------------------------------*/
 
 braid_Int
-braid_FlushConvHistory(braid_Core core,    
+braid_WriteConvHistory(braid_Core core,    
                        const char* filename)
 {
    braid_Int     myid          = _braid_CoreElt(core, myid_world);
@@ -1216,30 +1216,30 @@ braid_FlushConvHistory(braid_Core core,
 
      /* Write some general information file */
      braidlog = fopen(filename, "w");
-     fprintf(braidlog,"# start time       = %e\n", tstart);
-     fprintf(braidlog,"# stop time        = %e\n", tstop);
-     fprintf(braidlog,"# time steps       = %d\n", (int) gupper);
-     fprintf(braidlog,"# number of levels = %d\n", nlevels);
-     fprintf(braidlog, "#  level   time-pts   cfactor\n");
+     _braid_ParFprintfFlush(braidlog, myid, "# start time       = %e\n", tstart);
+     _braid_ParFprintfFlush(braidlog, myid, "# stop time        = %e\n", tstop);
+     _braid_ParFprintfFlush(braidlog, myid, "# time steps       = %d\n", (int) gupper);
+     _braid_ParFprintfFlush(braidlog, myid, "# number of levels = %d\n", nlevels);
+     _braid_ParFprintfFlush(braidlog, myid, "#  level   time-pts   cfactor\n");
      for (level = 0; level < nlevels-1; level++)
      {
        cfac = _braid_GridElt(grids[level], cfactor);
        gupp = _braid_GridElt(grids[level], gupper);
-       fprintf(braidlog, "#  % 5d  % 8d  % 7d\n", level, gupp , cfac);
+       _braid_ParFprintfFlush(braidlog, myid, "#  % 5d  % 8d  % 7d\n", level, gupp , cfac);
      }
      /* Print out coarsest level information */
      gupp = _braid_GridElt(grids[level], gupper);
-     fprintf(braidlog, "#  % 5d  % 8d  \n\n", level, gupp);
+     _braid_ParFprintfFlush(braidlog, myid, "#  % 5d  % 8d  \n\n", level, gupp);
 
 
      /* Get and write residuals for all iterations */
      braid_GetNumIter(core, &niter);
      resnorms = _braid_CTAlloc(double, niter);
      braid_GetRNorms(core, &niter, resnorms);
-     fprintf(braidlog, "# iter   residual norm\n");
+     _braid_ParFprintfFlush(braidlog, myid, "# iter   residual norm\n");
      for (iter=0; iter<niter; iter++)
      {
-       fprintf(braidlog, "%03d      %1.14e\n", iter, resnorms[iter]);
+       _braid_ParFprintfFlush(braidlog, myid, "%03d      %1.14e\n", iter, resnorms[iter]);
      }
 
      /* Cleanup */

--- a/braid/braid.c
+++ b/braid/braid.c
@@ -1197,6 +1197,43 @@ braid_PrintStats(braid_Core  core)
  *--------------------------------------------------------------------------*/
 
 braid_Int
+braid_FlushConvHistory(braid_Core core,    
+                       const char* filename)
+{
+  FILE* braidlog;
+  int niter, ntime, nlevels;
+  int cfactor;
+
+  /* Get some general information from the core */
+  ntime = _braid_CoreElt(core, ntime); 
+  braid_GetNLevels(core, &nlevels);
+  _braid_GetCFactor(core, 0, &cfactor);
+
+  /* Get braid's residual norms for all iterations */
+  braid_GetNumIter(core, &niter);
+  double *norms = (double*) malloc(niter*sizeof(double));
+  braid_GetRNorms(core, &niter, norms);
+
+  /* Write to file */
+  braidlog = fopen(filename, "w");
+  fprintf(braidlog,"# ntime %d\n", (int) ntime);
+  fprintf(braidlog,"# cfactor %d\n", (int) cfactor);
+  fprintf(braidlog,"# nlevels %d\n", (int) nlevels);
+  for (int i=0; i<niter; i++)
+  {
+    fprintf(braidlog, "%d  %1.14e\n", i, norms[i]);
+  }
+  fprintf(braidlog, "\n\n\n");
+
+  free(norms);
+  
+  return _braid_error_flag;
+}
+
+/*--------------------------------------------------------------------------
+ *--------------------------------------------------------------------------*/
+
+braid_Int
 braid_SetMaxLevels(braid_Core  core,
                    braid_Int   max_levels)
 {

--- a/braid/braid.h
+++ b/braid/braid.h
@@ -529,6 +529,15 @@ braid_Int
 braid_PrintStats(braid_Core  core           /**< braid_Core (_braid_Core) struct*/
                  );
 
+
+/**
+ * After XBraid finishes, this function can be called to print out the convergence history (residuals for each iteration) to a file.
+ **/
+braid_Int
+braid_FlushConvHistory(braid_Core core,      /**< braid_Core (_braid_Core) struct */
+                       const char* filename  /**< Output file name */
+                       );
+
 /**
  * Set max number of multigrid levels.
  **/

--- a/braid/braid.h
+++ b/braid/braid.h
@@ -531,10 +531,11 @@ braid_PrintStats(braid_Core  core           /**< braid_Core (_braid_Core) struct
 
 
 /**
- * After Drive() finishes, this function can be called to print out the convergence history (residuals for each iteration) to a file.
+ * After Drive() finishes, this function can be called to write out the convergence history 
+ * (residuals for each iteration) to a file
  **/
 braid_Int
-braid_FlushConvHistory(braid_Core core,      /**< braid_Core (_braid_Core) struct */
+braid_WriteConvHistory(braid_Core core,      /**< braid_Core (_braid_Core) struct */
                        const char* filename  /**< Output file name */
                        );
 

--- a/braid/braid.h
+++ b/braid/braid.h
@@ -531,7 +531,7 @@ braid_PrintStats(braid_Core  core           /**< braid_Core (_braid_Core) struct
 
 
 /**
- * After XBraid finishes, this function can be called to print out the convergence history (residuals for each iteration) to a file.
+ * After Drive() finishes, this function can be called to print out the convergence history (residuals for each iteration) to a file.
  **/
 braid_Int
 braid_FlushConvHistory(braid_Core core,      /**< braid_Core (_braid_Core) struct */

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -1292,11 +1292,13 @@ can return a boolean variable to indicate correctness.
                           my_Access, my_Free, my_Clone, my_Sum, my_SpatialNorm, 
                           my_CoarsenBilinear, my_Refine);
 
-# More Complicated Examples {#complicatedexamples}
+# Fortan90 Interface, C++ Interface, and More Complicated Examples {#complicatedexamples}
 
-We have Fortran90 and C++ interfaces.  See ``examples/ex-01f.f90``, ``braid.hpp``
-and the various C++ examples in ``drivers/drive-**.cpp``.  For discussion of
-more complex problems please see our project
+We have Fortran90 and C++ interfaces.  For Fortran 90, see ``examples/ex-01f.f90``.
+For C++ see ``braid.hpp`` and ``examples/ex-01-pp.cpp``
+For more complicated C++ examples, see the various C++ examples in
+``drivers/drive-**.cpp``.  For a discussion of more complex problems please see
+our project
 [publications website](http://computation.llnl.gov/projects/parallel-time-integration-multigrid/publications)
 for our recent publications concerning some of these varied applications. 
 


### PR DESCRIPTION
Adding an interface routine (C) that can be called after braid_Drive(), in order to print the convergence history (residuals at all iterations) to a file. 