### PR TITLE
Changing printf to _braid_printf.

### DIFF
--- a/braid/adjoint.c
+++ b/braid/adjoint.c
@@ -53,7 +53,7 @@ _braid_VectorBarDelete(braid_Core core, braid_VectorBar bar)
    /* Sanity check */
    else if (bar->useCount < 0)
    {
-      printf("ERROR: useCount < 0 !\n");
+      _braid_printf("ERROR: useCount < 0 !\n");
       exit(0);
    }
  

--- a/braid/base.c
+++ b/braid/base.c
@@ -52,7 +52,7 @@ _braid_BaseStep(braid_Core       core,
    braid_Int        gupper      = _braid_CoreElt(core, gupper);
    braid_Real       tol         = _braid_CoreElt(core, tol);
 
-   if (verbose_adj) printf("%d: STEP %.4f to %.4f, %d\n", myid, t, tnext, tidx);
+   if (verbose_adj) _braid_printf("%d: STEP %.4f to %.4f, %d\n", myid, t, tnext, tidx);
 
    /* Record to the tape */
    if ( record )
@@ -121,7 +121,7 @@ _braid_BaseInit(braid_Core        core,
    braid_Int         record      = _braid_CoreElt(core, record);
    braid_Int         adjoint     = _braid_CoreElt(core, adjoint);
     
-   if (verbose_adj) printf("%d INIT\n", myid);
+   if (verbose_adj) _braid_printf("%d INIT\n", myid);
 
    /* Allocate the braid_BaseVector */
    u = (braid_BaseVector) malloc(sizeof(braid_Vector) + sizeof(braid_VectorBar));
@@ -178,7 +178,7 @@ _braid_BaseClone(braid_Core         core,
    braid_Int         record       = _braid_CoreElt(core, record);
    braid_Int         adjoint      = _braid_CoreElt(core, adjoint);
 
-   if (verbose_adj) printf("%d: CLONE\n", myid);
+   if (verbose_adj) _braid_printf("%d: CLONE\n", myid);
 
    /* Allocate the braid_BaseVector */
    v = (braid_BaseVector) malloc(sizeof(braid_Vector) + sizeof(braid_VectorBar));
@@ -236,7 +236,7 @@ _braid_BaseFree(braid_Core       core,
    braid_Int      adjoint     = _braid_CoreElt(core, adjoint);
    braid_Int      record      = _braid_CoreElt(core, record);
 
-   if (verbose_adj) printf("%d: FREE\n", myid);
+   if (verbose_adj) _braid_printf("%d: FREE\n", myid);
 
    /* Record to the tape */
    if ( record )
@@ -282,7 +282,7 @@ _braid_BaseSum(braid_Core        core,
    braid_Int        verbose_adj  =  _braid_CoreElt(core, verbose_adj);
    braid_Int        record       =  _braid_CoreElt(core, record);
 
-   if ( verbose_adj ) printf("%d: SUM\n", myid);
+   if ( verbose_adj ) _braid_printf("%d: SUM\n", myid);
 
    /* Record to the tape */
    if ( record )
@@ -339,7 +339,7 @@ _braid_BaseAccess(braid_Core          core,
    braid_Int        verbose_adj   = _braid_CoreElt(core, verbose_adj);
    braid_Int        record        = _braid_CoreElt(core, record);
    
-   if ( verbose_adj ) printf("%d: ACCESS\n", myid);
+   if ( verbose_adj ) _braid_printf("%d: ACCESS\n", myid);
 
    /* Record to the tape */
    if ( record )
@@ -369,7 +369,7 @@ _braid_BaseSync(braid_Core          core,
 {
    braid_Int        myid          = _braid_CoreElt(core, myid);
    braid_Int        verbose_adj   = _braid_CoreElt(core, verbose_adj);
-   if( verbose_adj ) printf("%d: SNYC\n", myid);
+   if( verbose_adj ) _braid_printf("%d: SNYC\n", myid);
 
    /* Do adjoint stuff here */
 
@@ -391,7 +391,7 @@ _braid_BaseBufSize(braid_Core          core,
    braid_Int  myid         = _braid_CoreElt(core, myid);
    braid_Int  verbose_adj  = _braid_CoreElt(core, verbose_adj);
 
-   if ( verbose_adj ) printf("%d: BUFSIZE\n", myid);
+   if ( verbose_adj ) _braid_printf("%d: BUFSIZE\n", myid);
 
    /* Call the users BufSize function */
    _braid_CoreFcn(core, bufsize)(app, size_ptr, status);
@@ -416,7 +416,7 @@ _braid_BaseBufPack(braid_Core          core,
    braid_Int        record       = _braid_CoreElt(core, record);
    braid_Int        sender       = _braid_CoreElt(core, send_recv_rank);
 
-   if ( verbose_adj ) printf("%d: BUFPACK\n",  myid );
+   if ( verbose_adj ) _braid_printf("%d: BUFPACK\n",  myid );
 
    /* Record to the tape */
    if ( record )
@@ -463,7 +463,7 @@ _braid_BaseBufUnpack(braid_Core          core,
    braid_Int        receiver     = _braid_CoreElt(core, send_recv_rank);
    braid_Real       tstart       = _braid_CoreElt(core, tstart);
 
-   if ( verbose_adj ) printf("%d: BUFUNPACK\n", myid);
+   if ( verbose_adj ) _braid_printf("%d: BUFUNPACK\n", myid);
 
    /* Allocate the braid_BaseVector */
    u = (braid_BaseVector) malloc(sizeof(braid_Vector) + sizeof(braid_VectorBar));
@@ -529,7 +529,7 @@ _braid_BaseObjectiveT(braid_Core             core,
    braid_Int        nrefine       = _braid_CoreElt(core, nrefine);
    braid_Int        gupper        = _braid_CoreElt(core, gupper);
    
-   if ( verbose_adj ) printf("%d: OBJECTIVET\n", myid);
+   if ( verbose_adj ) _braid_printf("%d: OBJECTIVET\n", myid);
 
    /* if bar: Record to the tape */
    if ( record )
@@ -575,7 +575,7 @@ _braid_BaseResidual(braid_Core        core,
    braid_Int        verbose_adj  = _braid_CoreElt(core, verbose_adj);
    braid_Int        myid         = _braid_CoreElt(core, myid);
 
-   if ( verbose_adj ) printf("%d: RESIDUAL\n", myid);
+   if ( verbose_adj ) _braid_printf("%d: RESIDUAL\n", myid);
 
    /* Call the users Residual function */
    _braid_CoreFcn(core, residual)(app, ustop->userVector, r->userVector, status);
@@ -596,7 +596,7 @@ _braid_BaseFullResidual(braid_Core        core,
    braid_Int        verbose_adj  = _braid_CoreElt(core, verbose_adj);
    braid_Int        myid         = _braid_CoreElt(core, myid);
 
-   if ( verbose_adj ) printf("%d: FULLRESIDUAL\n", myid);
+   if ( verbose_adj ) _braid_printf("%d: FULLRESIDUAL\n", myid);
 
    /* Call the users Residual function */
    _braid_CoreFcn(core, full_rnorm_res)(app, r->userVector, u->userVector, status);
@@ -618,7 +618,7 @@ _braid_BaseSCoarsen(braid_Core              core,
    braid_Int        verbose_adj  = _braid_CoreElt(core, verbose_adj);
    braid_Int        myid         = _braid_CoreElt(core, myid);
 
-   if ( verbose_adj ) printf("%d: SCOARSEN\n", myid);
+   if ( verbose_adj ) _braid_printf("%d: SCOARSEN\n", myid);
 
    cu = (braid_BaseVector) malloc(sizeof(braid_BaseVector));
 
@@ -644,7 +644,7 @@ _braid_BaseSRefine(braid_Core                 core,
    braid_Int        verbose_adj  = _braid_CoreElt(core, verbose_adj);
    braid_Int        myid         = _braid_CoreElt(core, myid);
 
-   if ( verbose_adj ) printf("%d: SREFINE\n", myid);
+   if ( verbose_adj ) _braid_printf("%d: SREFINE\n", myid);
 
    fu = (braid_BaseVector) malloc(sizeof(braid_BaseVector));
 
@@ -669,7 +669,7 @@ _braid_BaseSInit(braid_Core        core,
    braid_Int        verbose_adj  = _braid_CoreElt(core, verbose_adj);
    braid_Int        myid         = _braid_CoreElt(core, myid);
 
-   if ( verbose_adj ) printf("%d: SINIT\n", myid);
+   if ( verbose_adj ) _braid_printf("%d: SINIT\n", myid);
 
    u = (braid_BaseVector) malloc(sizeof(braid_BaseVector));
 
@@ -695,7 +695,7 @@ _braid_BaseSClone(braid_Core        core,
    braid_Int        verbose_adj  = _braid_CoreElt(core, verbose_adj);
    braid_Int        myid         = _braid_CoreElt(core, myid);
 
-   if ( verbose_adj ) printf("%d: SCLONE\n", myid);
+   if ( verbose_adj ) _braid_printf("%d: SCLONE\n", myid);
 
    v = (braid_BaseVector) malloc(sizeof(braid_BaseVector));
 
@@ -719,7 +719,7 @@ _braid_BaseSFree(braid_Core      core,
    braid_Int  verbose_adj  = _braid_CoreElt(core, verbose_adj);
    braid_Int  myid         = _braid_CoreElt(core, myid);
  
-   if ( verbose_adj ) printf("%d: SFREE\n", myid);
+   if ( verbose_adj ) _braid_printf("%d: SFREE\n", myid);
 
    /* Call the users sfree */
    _braid_CoreFcn(core, sfree)(app, u->userVector);
@@ -740,7 +740,7 @@ _braid_BaseTimeGrid(braid_Core  core,
    braid_Int  verbose_adj  = _braid_CoreElt(core, verbose_adj);
    braid_Int  myid         = _braid_CoreElt(core, myid);
  
-   if ( verbose_adj ) printf("%d: TIMEGRID\n", myid);
+   if ( verbose_adj ) _braid_printf("%d: TIMEGRID\n", myid);
 
    /* Call the users timegrid function */
    _braid_CoreFcn(core, tgrid)(app, ta, ilower, iupper);
@@ -770,7 +770,7 @@ _braid_BaseStep_diff(_braid_Action *action)
    braid_Int        verbose_adj  = _braid_CoreElt(core, verbose_adj);
    braid_Int        myid         = _braid_CoreElt(core, myid);
 
-   if ( verbose_adj ) printf("%d: STEP_DIFF %.4f to %.4f, %d\n", myid, inTime, outTime, tidx);
+   if ( verbose_adj ) _braid_printf("%d: STEP_DIFF %.4f to %.4f, %d\n", myid, inTime, outTime, tidx);
 
    /* Pop ustop & u from primal tape */
    ustop = (braid_Vector)    (_braid_CoreElt(core, userVectorTape)->data_ptr);
@@ -812,7 +812,7 @@ _braid_BaseClone_diff(_braid_Action *action)
    braid_Int       verbose_adj = _braid_CoreElt(core, verbose_adj);
    braid_Int       myid        = _braid_CoreElt(core, myid);
 
-   if ( verbose_adj ) printf("%d: CLONE_DIFF\n", myid);
+   if ( verbose_adj ) _braid_printf("%d: CLONE_DIFF\n", myid);
 
    /* Get and pop vbar from the tape */
    v_bar = (braid_VectorBar) (_braid_CoreElt(core, barTape)->data_ptr);
@@ -851,7 +851,7 @@ _braid_BaseSum_diff(_braid_Action *action)
    braid_Int       verbose_adj = _braid_CoreElt(core, verbose_adj);
    braid_Int       myid        = _braid_CoreElt(core, myid);
 
-   if ( verbose_adj ) printf("%d: SUM_DIFF\n", myid);
+   if ( verbose_adj ) _braid_printf("%d: SUM_DIFF\n", myid);
 
    /* Get and pop ybar from the tape */
    y_bar = (braid_VectorBar) (_braid_CoreElt(core, barTape)->data_ptr);
@@ -896,7 +896,7 @@ _braid_BaseObjectiveT_diff(_braid_Action *action)
    braid_Real             f_bar        = _braid_CoreElt(core, optim)->f_bar;
    braid_ObjectiveStatus  ostatus      = (braid_ObjectiveStatus) action->core;
 
-   if ( verbose_adj ) printf("%d: OBJT_DIFF\n", myid);
+   if ( verbose_adj ) _braid_printf("%d: OBJT_DIFF\n", myid);
 
    /* Get the primal and bar vectors from the tapes */
    u    = (braid_Vector)    (_braid_CoreElt(core, userVectorTape)->data_ptr);
@@ -946,7 +946,7 @@ _braid_BaseBufPack_diff(_braid_Action *action )
    braid_Int          myid            = _braid_CoreElt(core, myid);
    braid_BufferStatus bstatus         = (braid_BufferStatus) core;
 
-   if ( verbose_adj ) printf("%d: BUFPACK_DIFF\n", myid);
+   if ( verbose_adj ) _braid_printf("%d: BUFPACK_DIFF\n", myid);
 
    /* Get the bar vector and pop it from the tape*/
    ubar = (braid_VectorBar) (_braid_CoreElt(core, barTape)->data_ptr);
@@ -995,7 +995,7 @@ _braid_BaseBufUnpack_diff(_braid_Action *action)
    braid_Int           verbose_adj    = _braid_CoreElt(core, verbose_adj);
    braid_Int           myid           = _braid_CoreElt(core, myid);
 
-   if ( verbose_adj ) printf("%d: BUFUNPACK_DIFF\n", myid);
+   if ( verbose_adj ) _braid_printf("%d: BUFUNPACK_DIFF\n", myid);
 
    /* Get the bar vector and pop it from the tape*/
    ubar = (braid_VectorBar) (_braid_CoreElt(core, barTape)->data_ptr);

--- a/braid/braid.c
+++ b/braid/braid.c
@@ -765,7 +765,7 @@ braid_SetPrintFile(braid_Core     core,
    {
       if ((_braid_printfile = fopen(printfile_name, "w")) == NULL)
       {
-         printf("  Braid: Error: can't open output file %s\n", printfile_name);
+         _braid_printf("  Braid: Error: can't open output file %s\n", printfile_name);
          exit(1);
       }
    }

--- a/braid/tape.c
+++ b/braid/tape.c
@@ -45,7 +45,7 @@ _braid_TapePush(_braid_Tape* head, void* data_ptr)
    _braid_Tape* tmp = (_braid_Tape*)malloc(sizeof(_braid_Tape));
    if (tmp == NULL)
    {
-      printf("MALLOC ERROR!\n") ;
+      _braid_printf("MALLOC ERROR!\n") ;
       exit(1);
    }
    if ( _braid_TapeIsEmpty(head) ) tmp->size = 1;
@@ -106,7 +106,7 @@ _braid_TapeDisplayBackwards(braid_Core core, _braid_Tape* head, void (*displayfc
    }
    else
    {
-       printf("Tape is empty\n");
+       _braid_printf("Tape is empty\n");
    }
   
   return _braid_error_flag;

--- a/braid/tape.h
+++ b/braid/tape.h
@@ -29,6 +29,7 @@
 #define _braid_tape_HEADER
 
 #include "_braid.h"
+#include "util.h"
 #include "braid.h"
 
 /**


### PR DESCRIPTION
This branch exchanges calls to 'printf' by '_braid_printf' in (almost) all files. 

Some remaining 'printf' statements are in **refine.c**, in DEBUG mode. I wasn't sure if those should be changed to. 