### PR TITLE
Added SetPeriodic to C++ interface

### DIFF
--- a/braid/braid.hpp
+++ b/braid/braid.hpp
@@ -536,6 +536,8 @@ public:
       braid_SetSpatialRefine(core, _BraidAppRefine);
    }
 
+   void SetPeriodic(braid_Int periodic) { braid_SetPeriodic(core, periodic); }
+
    void SetSync() { braid_SetSync(core, _BraidAppSync); }
 
    void SetResidual() { braid_SetResidual(core, _BraidAppResidual); }


### PR DESCRIPTION
Allows the C++ interface to enable the periodic functionality in XBraid. 

(This is an old change on my end that I just realized I never created a pull request for.)