### PR TITLE
Send time information to neighboring empty processors for AMR subcycling purposes

### DIFF
--- a/braid/hierarchy.c
+++ b/braid/hierarchy.c
@@ -42,6 +42,7 @@ _braid_InitHierarchy(braid_Core    core,
    braid_Int     *rfactors   = _braid_CoreElt(core, rfactors);
    braid_Real   **rdtvalues  = _braid_CoreElt(core, rdtvalues);
    braid_Int      nlevels    = _braid_CoreElt(core, nlevels);
+   braid_Int      proc_id    = _braid_CoreElt(core, myid);
    _braid_Grid  **grids      = _braid_CoreElt(core, grids);
 
 
@@ -69,7 +70,7 @@ _braid_InitHierarchy(braid_Core    core,
 
    braid_Int         level;
    braid_Int         ilower, iupper;
-   braid_Int         clower, cupper, cfactor, ncpoints, nupoints;
+   braid_Int         clower, cupper, cfactor, ncpoints, nupoints, nprocs;
    braid_Real       *ta;
    braid_BaseVector *ua;
    braid_BaseVector *va;
@@ -78,11 +79,14 @@ _braid_InitHierarchy(braid_Core    core,
    _braid_Grid      *grid;
    braid_Real       *f_ta;
    braid_Int         i, j, f_i, f_ilower, clo, chi, gclower, gcupper;
-                    
-   MPI_Request       request1, request2;
+   braid_Int         num_empty_left_proc, num_empty_right_proc, proc;
+   braid_Int         max_empty_right_proc;
+
+   MPI_Request       request1, request2, request3, request4;
    MPI_Status        status;
    braid_Int         left_proc, right_proc;
 
+   MPI_Comm_size(comm, &nprocs);
    grids[0] = fine_grid;
 
    /* Do sequential time marching if min_coarse is already reached */
@@ -249,12 +253,40 @@ _braid_InitHierarchy(braid_Core    core,
       ilower = _braid_GridElt(grid, ilower);
       iupper = _braid_GridElt(grid, iupper);
       ta     = _braid_GridElt(grid, ta);
+      _braid_GetProc(core, level, ilower-1, &left_proc);
+      _braid_GetProc(core, level, iupper+1, &right_proc);
 
       if (ilower <= iupper)
       {
-         _braid_GetProc(core, level, ilower-1, &left_proc);
-         _braid_GetProc(core, level, iupper+1, &right_proc);
-         
+         /* Post send to fill time values on empty processors to the left */
+         num_empty_left_proc = proc_id-left_proc-1;
+         if (num_empty_left_proc > 0 && proc_id > 0)
+         {
+            for(proc = proc_id-1; proc > left_proc; proc--)
+            {
+               MPI_Send(&ta[0], sizeof(braid_Real), MPI_BYTE, proc, 1, comm);
+            }
+         }
+
+         /* Post send to fill time values on empty processors to the right */
+         if(right_proc == -1)
+         {
+            max_empty_right_proc = nprocs;
+         }
+         else
+         {
+            max_empty_right_proc = right_proc;
+         }
+         num_empty_right_proc = max_empty_right_proc-proc_id-1;
+         if (num_empty_right_proc > 0 && proc_id < max_empty_right_proc)
+         {
+            for(proc = proc_id+1; proc < max_empty_right_proc; proc++)
+            {
+               MPI_Send(&ta[iupper-ilower], sizeof(braid_Real), MPI_BYTE,
+                        proc, 1, comm);
+            }
+         }
+
          /* Post receive to set ta[-1] on each processor*/
          if (left_proc > -1)
          {
@@ -301,6 +333,30 @@ _braid_InitHierarchy(braid_Core    core,
          if ( (right_proc > -1) && ( _braid_CoreElt(core, scoarsen) != NULL ) )
          {
             MPI_Wait(&request2, &status);
+         }
+      }
+      else
+      {
+         /* Send ta information to idle processors for AMR subcycling purposes */
+         ilower -= 1;
+         iupper += 1;
+         if(left_proc > -1)
+         {
+            MPI_Irecv(&ta[-1], sizeof(braid_Real), MPI_BYTE, left_proc, 1, comm, &request3);
+         }
+
+         if(right_proc > -1)
+         {
+            MPI_Irecv(&ta[0], sizeof(braid_Real), MPI_BYTE, right_proc, 1, comm, &request4);
+         }
+         if(left_proc > -1)
+         {
+            MPI_Wait(&request3, &status);
+         }
+
+         if(right_proc > -1)
+         {
+            MPI_Wait(&request4, &status);
          }
       }
    }


### PR DESCRIPTION
When constructing a new hierarchy, this sends time information to empty processors. Empty processors are defined as those that have no time points on them. 

Time information on empty processors is needed for AMR subcycling. We need the empty processors to have the correct next and previous times so that during Sync we update AMR information such as the previous and next support level time point. This information is needed on empty processors so that if the processor later becomes used (like from a temporal refinement), then we have this information ready. 

Essentially the way this works is:
1. If this is NOT an empty processor:
1.1. Send our lower time value (ta[0]) to empty processors to the left. There is an assumption that time processor 0 is never empty.
1.2. Send our upper time value (ta[iupper-ilower]) to empty processors to the right.

2. If this is an empty processor:
2.1 Post receives to the first non-empty processor to the left and right
2.2 Fill the ta[-1] time value with the value received from the left processor
2.3 Fill the ta[0] time value with the value received from the right processor