### PR TITLE
Short bugfix when _braid_Drive() is called multiple times using the same core.

### DIFF
--- a/braid/braid.c
+++ b/braid/braid.c
@@ -156,11 +156,14 @@ braid_Drive(braid_Core  core)
       }
    }
 
-   /* Turn on warm_restart, so further calls to braid_drive() don't initialize the grid again. */
-   _braid_CoreElt(core, warm_restart) = 1;
+   /* Reset from previous calls to braid_drive() */
+   _braid_CoreElt(core, done) = 0;
 
    /* Solve with MGRIT */
    _braid_Drive(core, localtime);
+
+   /* Turn on warm_restart, so further calls to braid_drive() don't initialize the grid again. */
+   _braid_CoreElt(core, warm_restart) = 1;
 
    /* Stop timer */
    localtime = MPI_Wtime() - localtime;


### PR DESCRIPTION
* The core's 'done' flag is set to 0 before _braid_drive is called.
* The 'warm_restart' flag is set to true only **after** _braid_Drive finishes, instead of before. 