### PR TITLE
New branch for julia interface pull request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ wrapperTests.txt
 # binaries
 # as these are build-dependent, binaries should not be committed
 *.o
+*.so
 *.a
 ex-01
 ex-01-adjoint

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,9 @@ all: braid examples
 
 braid: 
 	cd braid; $(MAKE)
+ifeq ($(shared),yes)
+		cd braid; $(MAKE) libbraid.so
+endif
 
 examples: ./braid/libbraid.a
 	cd examples; $(MAKE)

--- a/braid/Makefile
+++ b/braid/Makefile
@@ -89,8 +89,12 @@ libbraid.a: $(BRAID_HEADERS) $(BRAID_OBJ)
 	ar cruv libbraid.a $(BRAID_OBJ)
 	ranlib libbraid.a
 
+libbraid.so: $(BRAID_HEADERS) $(BRAID_OBJ)
+	@echo "Building" $@ "..."
+	$(MPICC) $(SEQFLAGS) $(CFLAGS) $(SHAREDFLAGS) $(BRAID_OBJ) -o $@
+
 all: libbraid.a 
 
 clean:
-	rm -f *.o libbraid.a
+	rm -f *.o libbraid.a libbraid.so
 

--- a/braid/braid.c
+++ b/braid/braid.c
@@ -493,7 +493,6 @@ braid_Destroy(braid_Core  core)
       braid_App               app             = _braid_CoreElt(core, app);
       braid_Int               nlevels         = _braid_CoreElt(core, nlevels);
       _braid_Grid           **grids           = _braid_CoreElt(core, grids);
-      braid_Int               cfactor         = _braid_GridElt(grids[0], cfactor);
       braid_Int               gupper          = _braid_CoreElt(core, gupper);
       braid_Int               richardson      = _braid_CoreElt(core, richardson);
       braid_Int               est_error       = _braid_CoreElt(core, est_error); 
@@ -509,24 +508,54 @@ braid_Destroy(braid_Core  core)
       _braid_TFree(_braid_CoreElt(core, tnorm_a));
       _braid_TFree(_braid_CoreElt(core, rdtvalues));
 
-      /* Destroy stored Lyapunov exponents */
-      if (_braid_CoreElt(core, lyap_exp))
+      if (grids[0] != NULL)
       {
+         braid_Int cfactor = _braid_GridElt(grids[0], cfactor);
+         /* Destroy stored Lyapunov exponents */
+         if (_braid_CoreElt(core, lyap_exp))
+         {
 
-         braid_Int npoints; 
-         if (nlevels == 1)
-         {
-            npoints = _braid_GridElt(grids[0], iupper) - _braid_GridElt(grids[0], ilower);
+            braid_Int npoints; 
+            if (nlevels == 1)
+            {
+               npoints = _braid_GridElt(grids[0], iupper) - _braid_GridElt(grids[0], ilower);
+            }
+            else
+            {
+               npoints = _braid_GridElt(grids[0], ncpoints);
+            }
+            for (braid_Int i = 0; i < npoints; i++)
+            {
+               _braid_TFree(_braid_CoreElt(core, local_exponents)[i]);
+            }
+            _braid_TFree(_braid_CoreElt(core, local_exponents));
          }
-         else
+
+
+         /* Free last time step, if set */
+         if ( (_braid_CoreElt(core, storage) < 0) && !(_braid_IsCPoint(gupper, cfactor)) )
          {
-            npoints = _braid_GridElt(grids[0], ncpoints);
+            if (_braid_GridElt(grids[0], ulast) != NULL)
+            {
+            _braid_BaseFree(core, app, _braid_GridElt(grids[0], ulast));
+            }
          }
-         for (braid_Int i = 0; i < npoints; i++)
+
+         /* Destroy Richardson estimate structures */
+         if ( richardson || est_error )
          {
-            _braid_TFree(_braid_CoreElt(core, local_exponents)[i]);
+            _braid_TFree(_braid_CoreElt(core, dtk));
+            if (est_error)
+            {
+               _braid_TFree(_braid_CoreElt(core, estimate));
+            }
          }
-         _braid_TFree(_braid_CoreElt(core, local_exponents));
+
+         for (level = 0; level < nlevels; level++)
+         {
+            _braid_GridDestroy(core, grids[level]);
+         }
+
       }
 
       /* Destroy the optimization structure */
@@ -537,47 +566,19 @@ braid_Destroy(braid_Core  core)
          _braid_TFree(_braid_CoreElt(core, optim));
       }
 
-      /* Free last time step, if set */
-      if ( (_braid_CoreElt(core, storage) < 0) && !(_braid_IsCPoint(gupper, cfactor)) )
-      {
-         if (_braid_GridElt(grids[0], ulast) != NULL)
-         {
-           _braid_BaseFree(core, app, _braid_GridElt(grids[0], ulast));
-         }
-      }
-
-      /* Destroy Richardson estimate structures */
-      if ( richardson || est_error )
-      {
-         _braid_TFree(_braid_CoreElt(core, dtk));
-         if (est_error)
-         {
-            _braid_TFree(_braid_CoreElt(core, estimate));
-         }
-      }
-
-      for (level = 0; level < nlevels; level++)
-      {
-         _braid_GridDestroy(core, grids[level]);
-      }
-
       _braid_TFree(grids);
-
       _braid_TFree(core);
    
       if (timer_file_stem != NULL)
       {
          _braid_TFree(timer_file_stem);
       }
-
    }
 
    if (_braid_printfile != NULL)
    {
       fclose(_braid_printfile);
    }
-   
-
 
    return _braid_error_flag;
 }

--- a/braid/braid.h
+++ b/braid/braid.h
@@ -57,15 +57,15 @@ extern "C" {
  */
 
 /** Define Fortran name-mangling schema, there are four supported options, see braid_F90_iface.c */
-#define braid_FMANGLE 1
+#define braid_FMANGLE 0
 /** Turn on the optional user-defined spatial coarsening and refinement functions */ 
 #define braid_Fortran_SpatialCoarsen 0
 /** Turn on the optional user-defined residual function */ 
-#define braid_Fortran_Residual 1
+#define braid_Fortran_Residual 0
 /** Turn on the optional user-defined time-grid function */ 
-#define braid_Fortran_TimeGrid 1
+#define braid_Fortran_TimeGrid 0
 /** Turn on the optional user-defined sync function */
-#define braid_Fortran_Sync 1
+#define braid_Fortran_Sync 0
 
 /** @} */
 
@@ -605,7 +605,7 @@ braid_PrintTimers(braid_Core  core           /**< braid_Core (_braid_Core) struc
  **/
 braid_Int
 braid_ResetTimer(braid_Core  core           /**< braid_Core (_braid_Core) struct*/
-);
+                );
 
 /**
  * After Drive() finishes, this function can be called to write out the convergence history 

--- a/braid/braid.jl/XBraid.jl
+++ b/braid/braid.jl/XBraid.jl
@@ -1,0 +1,732 @@
+#=BHEADER**********************************************************************
+ * Copyright (c) 2013, Lawrence Livermore National Security, LLC. 
+ * Produced at the Lawrence Livermore National Laboratory.
+ * 
+ * This file is part of XBraid. For support, post issues to the XBraid Github page.
+ * 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free Software
+ * Foundation) version 2.1 dated February 1999.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the terms and conditions of the GNU General Public
+ * License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ ***********************************************************************EHEADER=#
+
+module XBraid
+# Not sure we want to export anything...
+# export Init, Drive, etc.
+
+# BEGIN MODULE XBraid
+using Serialization: serialize, deserialize, Serializer # used to pack arbitrary julia objects into buffers
+using LinearAlgebra: norm2
+using MPI
+
+include("status.jl")
+include("wrapper_functions.jl")
+
+#=
+ |  For this to work, XBraid must be compiled as a shared library.
+ |  $ make braid shared=yes
+ |  and the Fortran flags braid_Fortran_SpatialCoarsen, braid_Fortran_Residual,
+ |  braid_Fortran_TimeGrid, and braid_Fortran_Sync must all be set to zero in
+ |  braid.h before compiling. (TODO: figure out why this is...)
+ =#
+libbraid = joinpath(dirname(@__DIR__), "libbraid.so")
+
+c_stdout = Libc.FILE(Libc.RawFD(1), "w")  # corresponds to C standard output
+function malloc_null_double_ptr(T::Type)
+	pp = Base.Libc.malloc(sizeof(Ptr{Cvoid}))
+	pp = reinterpret(Ptr{Ptr{T}}, pp)
+	return pp
+end
+
+# This can contain anything (TODO: do I even need this?)
+mutable struct BraidVector{T}
+	user_vector::T
+	VecType::Type
+end
+BraidVector(u::T) where T = BraidVector(u, T)
+
+OptionalFunction = Union{Function, Nothing}
+"""
+This is an internal structure that is not generally exposed to the user.
+This enables the user interface to only use memory safe function calls.
+User defined data structures that are not time-dependent can be declared in 
+the global scope, or they can be packed into a user defined object and passed to
+Init(), in which case the object will be passed as the first argument in step, sum, spatialnorm, and access.
+_app.user_app is passed as the first argument to some user defined function.
+Stores any time-independent data the user may need to compute a time-step.
+Large, preallocate arrays should be packed into this object, since operations
+involving globally scoped variables are slower than local variables.
+struct braid_App end
+
+This may be manually contructed in order to pass to test functions.
+
+julia> app = BraidApp(my_app, MPI.COMM_WORLD, MPI.COMM_WORLD, my_step, my_init, my_sum, my_norm, my_access);
+
+julia> testSpatialNorm(app, 0.);
+ """
+mutable struct BraidApp
+	user_app::Any     # user defined app data structure
+
+	comm::MPI.Comm    # global mpi communicator
+	comm_t::MPI.Comm  # temporal mpi communicator
+
+	# user functions
+	step::Function
+	init::Function
+	sum::Function
+	spatialnorm::Function
+	access::Function
+
+	basis_init::OptionalFunction
+	inner_prod::OptionalFunction
+
+	# dictionary to store globally scoped references to allocated braid_vector objects
+	ref_ids::IdDict{UInt64, BraidVector}
+	bufsize::Integer  # expected serialized size of user's vector
+	bufsize_lyap::Integer
+	user_AppType::Type
+	user_VecType::Type
+	user_BasType::Type
+end
+
+# some default functions assuming the user's vector is a julia array
+function default_sum!(app, α::Real, x::AbstractArray, β::Real, y::AbstractArray)
+	y .= α .* x .+ β .* y
+	return
+end
+
+function default_norm(app, u::AbstractArray)
+	return norm2(u)
+end
+
+function default_inner_prod(app, u::AbstractArray, v::AbstractArray)
+	return u ⋅ v
+end
+
+# default constructor
+function BraidApp(app, comm::MPI.Comm, comm_t::MPI.Comm, step::Function, init::Function, sum::Function, norm::Function, access::Function, basis_init::Function, inner_prod::Function)
+	BraidApp(app, comm, comm_t, step, init, sum, norm, access, basis_init, inner_prod, IdDict(), 0, 0, Nothing, Nothing, Nothing)
+end
+
+function BraidApp(app, comm::MPI.Comm, comm_t::MPI.Comm, step::Function, init::Function, sum::Function, norm::Function, access::Function)
+	BraidApp(app, comm, comm_t, step, init, sum, norm, access, nothing, nothing, IdDict(), 0, 0, Nothing, Nothing, Nothing)
+end
+
+function BraidApp(app, comm::MPI.Comm, step::Function, init::Function, sum::Function, norm::Function, access::Function)
+	BraidApp(app, comm, comm, step, init, sum, norm, access)
+end
+
+function BraidApp(app, comm::MPI.Comm, step, init, access)
+	BraidApp(app, comm, comm, step, init, default_sum!, default_norm, access)
+end
+
+function BraidApp(app, comm::MPI.Comm, step, init, access, basis_init)
+	BraidApp(app, comm, comm, step, init, default_sum!, default_norm, access, basis_init, default_inner_prod)
+end
+
+"""
+Stores all the information needed to run XBraid. Create this object with Init(), then pass this to Drive() to run XBraid.
+
+julia> core = XBraid.Init(MPI.COMM_WORLD, MPI.COMM_WORLD, 
+
+julia> XBraid.Drive(core);
+
+"""
+mutable struct BraidCore
+	# internal values
+	_braid_core::Ptr{Cvoid}
+	_braid_app::BraidApp
+	tstart::Float64
+	tstop::Float64
+	ntime::Int32
+	function BraidCore(_braid_core, _braid_app, tstart, tstop, ntime)
+		x = new(_braid_core, _braid_app, tstart, tstop, ntime)
+		finalizer(x) do core
+			# @async println("Destroying BraidCore $(core._braid_core)")
+			@ccall libbraid.braid_Destroy(core._braid_core::Ptr{Cvoid})::Cint
+		end
+	end
+end
+
+"""
+Used to add a reference to the vector u to the IdDict stored in the app.
+this keeps all newly allocated braid_vectors in the global scope, preventing them from being garbage collected. 
+"""
+function _register_vector(app::BraidApp, u::BraidVector)
+	app.ref_ids[objectid(u)] = u
+end
+
+"""
+Used to remove a reference to the vector u to the IdDict stored in the app.
+"""
+function _deregister_vector(app::BraidApp, u::BraidVector)
+	id = objectid(u)::UInt64
+	pop!(app.ref_ids, id)
+end
+
+function postInitPrecompile(app::BraidApp)
+	#= 
+	# This is a hack to make sure every processor knows how big the user's vector will be.
+	# We can also take this time to precompile the user's step function so it doesn't happen
+	# in serial on the coarse grid.
+	=#
+	GC.enable(false) # disable garbage collection
+	app_ptr = pointer_from_objref(app)::Ptr{Cvoid}
+	pp = malloc_null_double_ptr(Cvoid)
+
+	_jl_init!(app_ptr, 0., pp)
+	u_ptr = unsafe_load(pp)
+	u = unsafe_pointer_to_objref(u_ptr)::BraidVector
+	VecType = typeof(u.user_vector)
+	AppType = typeof(app.user_app)
+	
+	!precompile(app.step, 	    (AppType, Ptr{Cvoid}, VecType, VecType, Float64, Float64)) && println("failed to precompile step")
+	!precompile(app.spatialnorm, (AppType, VecType)) && println("failed to precompile norm")
+	!precompile(app.sum,         (AppType, Float64, VecType, Float64, VecType)) && println("failed to precompile sum")
+	if app.access !== nothing 
+		!precompile(app.access,  (AppType, Ptr{Cvoid}, VecType)) && println("failed to precompile access")
+	end
+
+	# some julia functions that can be precompiled
+	precompile(deepcopy, (BraidVector{VecType},))
+	precompile(unsafe_store!, (Ptr{Float64}, Float64,))
+	precompile(Tuple{typeof(Base.getproperty), BraidVector{VecType}, Symbol})
+	precompile(Tuple{typeof(Base.unsafe_store!), Ptr{Int32}, Int64})
+	precompile(Tuple{typeof(deserialize), Serializer{Base.GenericIOBuffer{Array{UInt8, 1}}}, DataType})
+	precompile(Tuple{typeof(Base.unsafe_wrap), Type{Array{UInt8, 1}}, Ptr{UInt8}, Int64})
+	precompile(Tuple{Type{NamedTuple{(:read, :write, :maxsize), T} where T<:Tuple}, Tuple{Bool, Bool, Int64}})
+
+	_jl_free!(app_ptr, u_ptr)
+	Base.Libc.free(pp)
+	GC.enable(true) # re-enable garbage collection
+	
+	app.user_AppType = AppType
+	app.user_VecType = VecType
+end
+
+function deltaPrecompile(app::BraidApp)
+	GC.enable(false)
+	app_ptr = pointer_from_objref(app)::Ptr{Cvoid}
+	pp = malloc_null_double_ptr(Cvoid)
+	AppType = app.user_AppType
+	VecType = app.user_VecType
+
+	_jl_init_basis!(app_ptr, 0., Int32(0), pp)
+	ψ_ptr = unsafe_load(pp)
+	ψ = unsafe_pointer_to_objref(ψ_ptr)
+	BasType = typeof(ψ.user_vector)
+	println("precompiling user Delta functions")
+	!precompile(app.step,       (AppType, Ptr{Cvoid}, VecType, VecType, Float64, Float64, Vector{BasType})) && println("failed to compile step_du")
+	!precompile(app.inner_prod, (AppType, VecType, VecType)) && println("failed to compile inner_prod u⋅u")
+	!precompile(app.inner_prod, (AppType, BasType, VecType)) && println("failed to compile inner_prod ψ⋅u")
+	!precompile(app.inner_prod, (AppType, VecType, BasType)) && println("failed to compile inner_prod u⋅ψ")
+	!precompile(app.inner_prod, (AppType, BasType, BasType)) && println("failed to compile inner_prod ψ⋅ψ")
+
+	_jl_free!(app_ptr, ψ_ptr)
+	Base.Libc.free(pp)
+	GC.enable(true)
+
+	app.user_BasType = BasType
+end
+
+"""
+Create a new BraidCore object. The BraidCore object is used to run the XBraid solver, and is destroyed when the object is garbage collected.
+"""
+function Init(comm_world::MPI.Comm, comm_t::MPI.Comm,
+	tstart::Real, tstop::Real, ntime::Integer,
+	step::Function, init::Function, sum::Function, spatialnorm::Function, access::OptionalFunction;
+	app = nothing
+)::BraidCore
+	_app = BraidApp(app, comm_world, comm_t, step, init, sum, spatialnorm, access)
+	_core_ptr = malloc_null_double_ptr(Cvoid)
+
+	GC.@preserve _core_ptr begin
+		@ccall libbraid.braid_Init(
+			_app.comm::MPI.MPI_Comm, _app.comm_t::MPI.MPI_Comm,
+			tstart::Cdouble, tstop::Cdouble, ntime::Cint,
+			_app::Ref{BraidApp}, _c_step::Ptr{Cvoid}, _c_init::Ptr{Cvoid}, _c_clone::Ptr{Cvoid},
+			_c_free::Ptr{Cvoid}, _c_sum::Ptr{Cvoid}, _c_norm::Ptr{Cvoid}, _c_access::Ptr{Cvoid},
+			_c_bufsize::Ptr{Cvoid}, _c_bufpack::Ptr{Cvoid}, _c_bufunpack::Ptr{Cvoid},
+			_core_ptr::Ptr{Ptr{Cvoid}},
+		)::Cint
+	end
+
+	_core = unsafe_load(_core_ptr)
+	Base.Libc.free(_core_ptr)
+
+	return BraidCore(_core, _app, tstart, tstop, ntime)
+end
+
+function Init(comm_world::MPI.Comm, tstart::Real, tstop::Real, ntime::Integer, step::Function, init::Function, access::OptionalFunction; app=nothing)
+	Init(comm_world, comm_world, tstart, tstop, ntime, step, init, default_sum!, default_norm, access; app=app)
+end
+
+"""
+Warmup the BraidCore object. XBraid.Drive calls this function automatically, but it can be called manually to precompile all user functions.
+
+This function is not necessary for XBraid to run, but it can significantly reduce the time to run the first time step. Note that this function calls all user functions, so if any user functions have side-effects, this may behave unexpectedly
+
+julia> XBraid.Warmup(core)
+
+Julia> XBraid.Drive(core; warmup=false)
+
+See also: XBraid.Drive
+"""
+function Warmup(core::BraidCore)
+	_app = core._braid_app
+	# precompile all user functions by calling them from braid_Warmup
+	# if any user functions have side-effects, this may behave unexpectedly
+	fdt = (core.tstop - core.tstart) / (core.ntime+1)
+	cdt = 2fdt
+
+	if (_app.basis_init !== nothing) && (_app.inner_prod !== nothing)
+		@ccall libbraid.braid_Warmup(
+			_app::Ref{BraidApp}, _app.comm::MPI.MPI_Comm, core.tstart::Cdouble, fdt::Cdouble, cdt::Cdouble,
+			_c_init::Ptr{Cvoid}, _c_access::Ptr{Cvoid}, _c_free::Ptr{Cvoid},
+			_c_clone::Ptr{Cvoid}, _c_sum::Ptr{Cvoid}, _c_norm::Ptr{Cvoid},
+			_c_bufsize::Ptr{Cvoid}, _c_bufpack::Ptr{Cvoid}, _c_bufunpack::Ptr{Cvoid},
+			C_NULL::Ptr{Cvoid}, C_NULL::Ptr{Cvoid}, _c_step::Ptr{Cvoid},
+			_c_init_basis::Ptr{Cvoid}, _c_inner_prod::Ptr{Cvoid}
+		)::Cint
+	else
+		@ccall libbraid.braid_Warmup(
+			_app::Ref{BraidApp}, _app.comm::MPI.MPI_Comm, core.tstart::Cdouble, fdt::Cdouble, cdt::Cdouble,
+			_c_init::Ptr{Cvoid}, _c_access::Ptr{Cvoid}, _c_free::Ptr{Cvoid},
+			_c_clone::Ptr{Cvoid}, _c_sum::Ptr{Cvoid}, _c_norm::Ptr{Cvoid},
+			_c_bufsize::Ptr{Cvoid}, _c_bufpack::Ptr{Cvoid}, _c_bufunpack::Ptr{Cvoid},
+			C_NULL::Ptr{Cvoid}, C_NULL::Ptr{Cvoid}, _c_step::Ptr{Cvoid},
+			C_NULL::Ptr{Cvoid}, C_NULL::Ptr{Cvoid}
+		)::Cint
+	end
+	nothing
+end
+
+"""
+Wraps the XBraid braid_Drive function. This function is called by XBraid.Drive, and should not be called directly.
+"""
+function _Drive(core::BraidCore)
+	GC.@preserve core begin
+		@ccall libbraid.braid_Drive(core._braid_core::Ptr{Cvoid})::Cint
+	end
+end
+
+"""
+Run the XBraid solver. This function calls XBraid.Warmup by default, but this can be disabled by setting warmup=false, in which case a less expensive (but less effective) option is used to precompile the user functions.
+"""
+function Drive(core::BraidCore; warmup=true)
+	if warmup
+		Warmup(core)
+	else
+		_app = core._braid_app
+		# cheaper precompile option, but less effective
+		begin
+			postInitPrecompile(_app)
+			if (_app.basis_init !== nothing) && (_app.inner_prod !== nothing)
+				deltaPrecompile(_app)
+			end
+		end
+	end
+	_Drive(core)
+end
+
+function PrintStats(core::BraidCore)
+	GC.@preserve core begin
+		@ccall libbraid.braid_PrintStats(core._braid_core::Ptr{Cvoid})::Cint
+	end
+end
+
+function SetTimerFile(core::BraidCore, filestem::String)
+	len = @ccall strlen(filestem::Cstring)::Cint
+	GC.@preserve core begin
+		@ccall libbraid.braid_SetTimerFile(core._braid_core::Ptr{Cvoid}, len::Cint, filestem::Cstring)::Cint
+	end
+end
+
+function PrintTimers(core::BraidCore)
+	GC.@preserve core begin
+		@ccall libbraid.braid_PrintTimers(core._braid_core::Ptr{Cvoid})::Cint
+	end
+end
+
+function ResetTimer(core::BraidCore)
+	GC.@preserve core begin
+		@ccall libbraid.braid_ResetTimer(core._braid_core::Ptr{Cvoid})::Cint
+	end
+end
+
+function SetTimings(core::BraidCore, timing_level::Integer)
+	GC.@preserve core begin
+		@ccall libbraid.braid_SetTimings(core._braid_core::Ptr{Cvoid}, timing_level::Cint)::Cint
+	end
+end
+
+function WriteConvHistory(core::BraidCore, filename::String)
+	GC.@preserve core begin
+		@ccall libbraid.braid_WriteConvHistory(core._braid_core::Ptr{Cvoid}, filename::Cstring)::Cint
+	end
+end
+
+function SetMaxLevels(core::BraidCore, max_levels::Integer)
+	@assert max_levels > 0 "Max. levels must be an integer greater than 0"
+	GC.@preserve core begin
+		@ccall libbraid.braid_SetMaxLevels(core._braid_core::Ptr{Cvoid}, max_levels::Cint)::Cint
+	end
+end
+
+function SetIncrMaxLevels(core::BraidCore)
+	GC.@preserve core begin
+		@ccall libbraid.braid_SetIncrMaxLevels(core._braid_core::Ptr{Cvoid})::Cint
+	end
+end
+
+function SetSkip(core::BraidCore, skip::Bool)
+	GC.@preserve core begin
+		@ccall libbraid.braid_SetSkip(core._braid_core::Ptr{Cvoid}, skip::Cint)::Cint
+	end
+end
+
+
+function SetRefine(core::BraidCore, refine::Bool)
+	GC.@preserve core begin
+		@ccall libbraid.braid_SetSkip(core._braid_core::Ptr{Cvoid}, refine::Cint)::Cint
+	end
+end
+
+function SetMaxRefinements(core::BraidCore, max_refinements::Integer)
+	GC.@preserve core begin
+		@ccall libbraid.braid_SetMaxRefinements(core._braid_core::Ptr{Cvoid}, max_refinements::Cint)::Cint
+	end
+end
+
+
+function SetTPointsCutoff(core::BraidCore, tpoints_cutoff::Integer)
+	GC.@preserve core begin
+		@ccall libbraid.braid_SetTPointsCutoff(core._braid_core::Ptr{Cvoid}, tpoints_cutoff::Cint)::Cint
+	end
+end
+
+
+function SetMinCoarse(core::BraidCore, min_coarse::Integer)
+	GC.@preserve core begin
+		@ccall libbraid.braid_SetMinCoarse(core._braid_core::Ptr{Cvoid}, min_coarse::Cint)::Cint
+	end
+end
+
+function SetRelaxOnlyCG(core::BraidCore, relax_only_cg::Bool)
+	GC.@preserve core begin
+		@ccall libbraid.braid_SetRelaxOnlyCG(core._braid_core::Ptr{Cvoid}, relax_only_cg::Cint)::Cint
+	end
+end
+
+function SetAbsTol(core::BraidCore, atol::Real)
+	GC.@preserve core begin
+		@ccall libbraid.braid_SetAbsTol(core._braid_core::Ptr{Cvoid}, atol::Cdouble)::Cint
+	end
+end
+
+function SetRelTol(core::BraidCore, rtol::Real)
+	GC.@preserve core begin
+		@ccall libbraid.braid_SetRelTol(core._braid_core::Ptr{Cvoid}, rtol::Cdouble)::Cint
+	end
+end
+
+function SetNRelax(core::BraidCore, level::Integer, nrelax::Integer)
+	GC.@preserve core begin
+		@ccall libbraid.braid_SetNRelax(core._braid_core::Ptr{Cvoid}, level::Cint, nrelax::Cint)::Cint
+	end
+end
+
+function SetCRelaxWt(core::BraidCore, level::Integer, Cwt::Real)
+	GC.@preserve core begin
+		@ccall libbraid.braid_SetCRelaxWt(core._braid_core::Ptr{Cvoid}, level::Cint, Cwt::Cdouble)::Cint
+	end
+end
+
+function SetCFactor(core::BraidCore, level::Integer, cfactor::Integer)
+	GC.@preserve core begin
+		@ccall libbraid.braid_SetCFactor(core._braid_core::Ptr{Cvoid}, level::Cint, cfactor::Cint)::Cint
+	end
+end
+
+function SetMaxIter(core::BraidCore, max_iter::Integer)
+	GC.@preserve core begin
+		@ccall libbraid.braid_SetMaxIter(core._braid_core::Ptr{Cvoid}, max_iter::Cint)::Cint
+	end
+end
+
+function SetFMG(core::BraidCore)
+	GC.@preserve core begin
+		@ccall libbraid.braid_SetFMG(core._braid_core::Ptr{Cvoid})::Cint
+	end
+end
+
+function SetNFMG(core::BraidCore, k::Integer)
+	GC.@preserve core begin
+		@ccall libbraid.braid_SetNFMG(core._braid_core::Ptr{Cvoid}, k::Cint)::Cint
+	end
+end
+
+function SetNFMGVcyc(core::BraidCore, nfmg_Vcyc::Integer)
+	GC.@preserve core begin
+		@ccall libbraid.braid_SetNFMGVcyc(core._braid_core::Ptr{Cvoid}, nfmg_Vcyc::Cint)::Cint
+	end
+end
+
+function SetStorage(core::BraidCore, storage::Bool)
+	GC.@preserve core begin
+		@ccall libbraid.braid_SetStorage(core._braid_core::Ptr{Cvoid}, storage::Cint)::Cint
+	end
+end
+
+function SetTemporalNorm(core::BraidCore, tnorm::Bool)
+	GC.@preserve core begin
+		@ccall libbraid.braid_SetTemporalNorm(core._braid_core::Ptr{Cvoid}, tnorm::Cint)::Cint
+	end
+end
+
+function SetPeriodic(core::BraidCore, periodic::Bool)
+	GC.@preserve core begin
+		@ccall libbraid.braid_SetPeriodic(core._braid_core::Ptr{Cvoid}, periodic::Cint)::Cint
+	end
+end
+
+function SetPrintLevel(core::BraidCore, print_level::Integer)
+	GC.@preserve core begin
+		@ccall libbraid.braid_SetPrintLevel(core._braid_core::Ptr{Cvoid}, print_level::Cint)::Cint
+	end
+end
+
+function SetFileIOLevel(core::BraidCore, io_level::Integer)
+	GC.@preserve core begin
+		@ccall libbraid.braid_SetFileIOLevel(core._braid_core::Ptr{Cvoid}, io_level::Cint)::Cint
+	end
+end
+
+function SetPrintFile(core::BraidCore, filename::String)
+	GC.@preserve core begin
+		@ccall libbraid.braid_SetPrintFile(core._braid_core::Ptr{Cvoid}, filename::Cstring)::Cint
+	end
+end
+
+function SetDefaultPrintFile(core::BraidCore)
+	GC.@preserve core begin
+		@ccall libbraid.braid_SetDefaultPrintFile(core._braid_core::Ptr{Cvoid})::Cint
+	end
+end
+
+"""
+Set access level for XBraid. This controls how often the user's access function is called.
+
+	- 0: Never call access function
+	- 1: Call access function only when XBraid is finished
+	- 2: Call access function at every XBraid iteration, on every level
+
+Default is 1.
+"""
+function SetAccessLevel(core::BraidCore, access_level::Integer)
+	GC.@preserve core begin
+		@ccall libbraid.braid_SetAccessLevel(core._braid_core::Ptr{Cvoid}, access_level::Cint)::Cint
+	end
+end
+
+function SetFinalFCRelax(core::BraidCore)
+	GC.@preserve core begin
+		@ccall libbraid.braid_SetFinalFCRelax(core._braid_core::Ptr{Cvoid})::Cint
+	end
+end
+
+function GetNumIter(core::BraidCore)
+	niter = Ref{Cint}(0)
+	GC.@preserve core begin
+		@ccall libbraid.braid_GetNumIter(core._braid_core::Ptr{Cvoid}, niter::Ref{Cint})::Cint
+	end
+	return niter[]
+end
+
+function GetRNorms(core::BraidCore)
+	nrequest = Ref{Cint}()
+	nrequest[] = GetNumIter(core)
+	rnorms = zeros(nrequest[])
+	GC.@preserve core begin
+		@ccall libbraid.braid_GetRNorms(core._braid_core::Ptr{Cvoid}, nrequest::Ref{Cint}, rnorms::Ref{Cdouble})::Cint
+	end
+	nrequest[] == 0 && return Float64[]
+	return rnorms[1:nrequest[]]
+end
+
+function GetNLevels(core::BraidCore)
+	nlevels = Ref(0)
+	GC.@preserve core begin
+		@ccall libbraid.braid_GetNLevels(core._braid_core::Ptr{Cvoid}, nlevels::Ref{Cint})::Cint
+	end
+	return nlevels[]
+end
+
+function SetSeqSoln(core::BraidCore, seq_soln::Bool)
+	GC.@preserve core begin
+		@ccall libbraid.braid_GetNLevels(core._braid_core::Ptr{Cvoid}, seq_soln::Cint)::Cint
+	end
+end
+
+function SetRichardsonEstimation(core::BraidCore, est_error::Bool, richardson::Bool, local_order::Integer)
+	GC.@preserve core begin
+		@ccall libbraid.braid_SetRichardsonEstimation(core._braid_core::Ptr{Cvoid}, est_error::Cint, richardson::Cint, local_order::Cint)::Cint
+	end
+end
+
+function SetDeltaCorrection(core::BraidCore, rank::Integer, basis_init::Function, inner_prod::Function)
+	core._braid_app.basis_init = basis_init
+	core._braid_app.inner_prod = inner_prod
+	# deltaPrecompile(core._braid_app)
+
+	GC.@preserve core begin
+		@ccall libbraid.braid_SetDeltaCorrection(core._braid_core::Ptr{Cvoid}, rank::Cint, _c_init_basis::Ptr{Cvoid}, _c_inner_prod::Ptr{Cvoid})::Cint
+	end
+end
+
+function SetDeferDelta(core::BraidCore, level::Integer, iter::Integer)
+	GC.@preserve core begin
+		@ccall libbraid.braid_SetDeferDelta(core._braid_core::Ptr{Cvoid}, level::Cint, iter::Cint)::Cint
+	end
+end
+
+function SetLyapunovEstimation(core::BraidCore; relax::Bool = false, cglv::Bool = true, exponents::Bool = false)
+	GC.@preserve core begin
+		@ccall libbraid.braid_SetLyapunovEstimation(core._braid_core::Ptr{Cvoid}, relax::Cint, cglv::Cint, exponents::Cint)::Cint
+	end
+end
+
+# Still missing spatial coarsening, sync, residual, and adjoint
+
+# braid_test
+function testInitAccess(app::BraidApp, t::Real, outputFile::Libc.FILE)
+	pass = @ccall libbraid.braid_TestInitAccess(
+		app::Ref{BraidApp},
+		app.comm::MPI.MPI_Comm,
+		outputFile::Libc.FILE,
+		t::Cdouble,
+		_c_init::Ptr{Cvoid},
+		_c_access::Ptr{Cvoid},
+		_c_free::Ptr{Cvoid},
+	)::Cint
+	return pass > 0
+
+	# println("Serialized size of user vector: $(app.bufsize)")
+	# println("Check output for objects not properly freed:")
+	# println(app.ref_ids)
+end
+testInitAccess(app::BraidApp, t::Real, outputFile::IO) = testInitAccess(app, t, Libc.FILE(outputFile))
+testInitAccess(app::BraidApp, t::Real) = testInitAccess(app, t, c_stdout)
+
+function testClone(app::BraidApp, t::Real, outputFile::Libc.FILE)
+	pass = @ccall libbraid.braid_TestClone(
+		app::Ref{BraidApp},
+		app.comm::MPI.MPI_Comm,
+		outputFile::Libc.FILE,
+		t::Cdouble,
+		_c_init::Ptr{Cvoid},
+		_c_access::Ptr{Cvoid},
+		_c_free::Ptr{Cvoid},
+		_c_clone::Ptr{Cvoid},
+	)::Cint
+	return pass > 0
+end
+testClone(app::BraidApp, t::Real, outputFile::IO) = testClone(app, t, Libc.FILE(outputFile))
+testClone(app::BraidApp, t::Real) = testClone(app, t, c_stdout)
+
+function testSum(app::BraidApp, t::Real, outputFile::Libc.FILE)
+	pass = @ccall libbraid.braid_TestSum(
+		app::Ref{BraidApp},
+		app.comm::MPI.MPI_Comm,
+		outputFile::Libc.FILE,
+		t::Cdouble,
+		_c_init::Ptr{Cvoid},
+		_c_access::Ptr{Cvoid},
+		_c_free::Ptr{Cvoid},
+		_c_clone::Ptr{Cvoid},
+		_c_sum::Ptr{Cvoid},
+	)::Cint
+	return pass > 0
+end
+testSum(app::BraidApp, t::Real, outputFile::IO) = testSum(app, t, Libc.FILE(outputFile))
+testSum(app::BraidApp, t::Real) = testSum(app, t, c_stdout)
+
+function testSpatialNorm(app::BraidApp, t::Real, outputFile::Libc.FILE)
+	pass = @ccall libbraid.braid_TestSpatialNorm(
+		app::Ref{BraidApp},
+		app.comm::MPI.MPI_Comm,
+		outputFile::Libc.FILE,
+		t::Cdouble,
+		_c_init::Ptr{Cvoid},
+		_c_free::Ptr{Cvoid},
+		_c_clone::Ptr{Cvoid},
+		_c_sum::Ptr{Cvoid},
+		_c_norm::Ptr{Cvoid},
+	)::Cint
+	return pass > 0
+end
+testSpatialNorm(app::BraidApp, t::Real, outputFile::IO) = testSpatialNorm(app, t, Libc.FILE(outputFile))
+testSpatialNorm(app::BraidApp, t::Real) = testSpatialNorm(app, t, c_stdout)
+
+function testBuf(app::BraidApp, t::Real, outputFile::Libc.FILE)
+	pass = @ccall libbraid.braid_TestBuf(
+		app::Ref{BraidApp},
+		app.comm::MPI.MPI_Comm,
+		outputFile::Libc.FILE,
+		t::Cdouble,
+		_c_init::Ptr{Cvoid},
+		_c_free::Ptr{Cvoid},
+		_c_sum::Ptr{Cvoid},
+		_c_norm::Ptr{Cvoid},
+		_c_bufsize::Ptr{Cvoid},
+		_c_bufpack::Ptr{Cvoid},
+		_c_bufunpack::Ptr{Cvoid},
+	)::Cint
+	return pass > 0
+	# print('\n')
+	# println("Check output for objects not freed:")
+	# println(app.ref_ids)
+end
+testBuf(app::BraidApp, t::Real, outputFile::IO) = testBuf(app, t, Libc.FILE(outputFile))
+testBuf(app::BraidApp, t::Real) = testBuf(app, t, c_stdout)
+
+function testDelta(app::BraidApp, t::Real, dt::Real, rank::Integer, outputFile::Libc.FILE)
+	app.basis_init::Function
+	app.inner_prod::Function
+	pass = @ccall libbraid.braid_TestDelta(
+		app::Ref{BraidApp},
+		app.comm::MPI.MPI_Comm,
+		outputFile::Libc.FILE,
+		t::Cdouble,
+		dt::Cdouble,
+		rank::Cint,
+		_c_init::Ptr{Cvoid},
+		_c_init_basis::Ptr{Cvoid},
+		_c_access::Ptr{Cvoid},
+		_c_free::Ptr{Cvoid},
+		_c_clone::Ptr{Cvoid},
+		_c_sum::Ptr{Cvoid},
+		_c_bufsize::Ptr{Cvoid},
+		_c_bufpack::Ptr{Cvoid},
+		_c_bufunpack::Ptr{Cvoid},
+		_c_inner_prod::Ptr{Cvoid},
+		_c_step::Ptr{Cvoid},
+	)::Cint
+	return pass > 0
+	# println("Check output for objects not freed:")
+	# println(app.ref_ids)
+end
+testDelta(app::BraidApp, t::Real, dt::Real, rank::Integer, outputFile::IO) = testDelta(app, t, dt, rank, Libc.FILE(outputFile))
+testDelta(app::BraidApp, t::Real, dt::Real, rank::Integer) = testDelta(app, t, dt, rank, c_stdout)
+
+# END MODULE XBraid
+end

--- a/braid/braid.jl/status.jl
+++ b/braid/braid.jl/status.jl
@@ -1,0 +1,173 @@
+#=BHEADER**********************************************************************
+ * Copyright (c) 2013, Lawrence Livermore National Security, LLC. 
+ * Produced at the Lawrence Livermore National Laboratory.
+ * 
+ * This file is part of XBraid. For support, post issues to the XBraid Github page.
+ * 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free Software
+ * Foundation) version 2.1 dated February 1999.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the terms and conditions of the GNU General Public
+ * License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ ***********************************************************************EHEADER=#
+
+# should these automatically qeuery the braid status for some commonly used values?
+struct StepStatus
+    ptr::Ptr{Cvoid}
+end
+
+struct AccessStatus
+    ptr::Ptr{Cvoid}
+end
+
+# @ccall requires these type annotations to be known at compile time, so macros won't work here
+function status_GetT(status::Union{StepStatus, AccessStatus})
+    t = Ref{Cdouble}()
+    @ccall libbraid.braid_StatusGetT(status.ptr::Ptr{Cvoid}, t::Ref{Cdouble})::Cint
+    return t[]
+end
+
+function status_GetTStop(status::StepStatus)
+    tstop = Ref{Cdouble}()
+    @ccall libbraid.braid_StatusGetTStop(status.ptr::Ptr{Cvoid}, tstop::Ref{Cdouble})::Cint
+    return tstop[]
+end
+
+function status_GetTstartTstop(status::StepStatus)
+    tstart, tstop = Ref{Cdouble}(), Ref{Cdouble}()
+    @ccall libbraid.braid_StepStatusGetTstartTstop(status.ptr::Ptr{Cvoid}, tstart::Ref{Cdouble}, tstop::Ref{Cdouble})::Cint
+    return tstart[], tstop[]
+end
+
+function status_GetTIndex(status::Union{StepStatus, AccessStatus})
+    ti = Ref{Cint}()
+    @ccall libbraid.braid_StatusGetTIndex(status.ptr::Ptr{Cvoid}, ti::Ref{Cint})::Cint
+    return ti[]
+end
+
+function status_GetLevel(status::Union{StepStatus, AccessStatus})
+    level = Ref{Cint}()
+    @ccall libbraid.braid_StatusGetLevel(status.ptr::Ptr{Cvoid}, level::Ref{Cint})::Cint
+    return level[]
+end
+
+function status_GetWrapperTest(status::Union{StepStatus, AccessStatus})
+    wtest = Ref{Cint}()
+    @ccall libbraid.braid_StatusGetWrapperTest(status.ptr::Ptr{Cvoid}, wtest::Ref{Cint})::Cint
+    return (wtest[] > 0)
+end
+
+function status_GetIter(status::Union{StepStatus, AccessStatus})
+    iter = Ref{Cint}()
+    @ccall libbraid.braid_StatusGetIter(status.ptr::Ptr{Cvoid}, iter::Ref{Cint})::Cint
+    return iter[]
+end
+
+function status_GetNLevels(status::Union{StepStatus, AccessStatus})
+    nlevels = Ref{Cint}()
+    @ccall libbraid.braid_StatusGetNLevels(status.ptr::Ptr{Cvoid}, nlevels::Ref{Cint})::Cint
+    return nlevels[]
+end
+
+function status_GetNTPoints(status::Union{StepStatus, AccessStatus})
+    ntpoints = Ref{Cint}()
+    @ccall libbraid.braid_StatusGetNTPoints(status.ptr::Ptr{Cvoid}, ntpoints::Ref{Cint})::Cint
+    return ntpoints[]
+end
+
+function status_GetResidual(status::Union{StepStatus, AccessStatus})
+    res = Ref{Cdouble}()
+    @ccall libbraid.braid_StatusGetResidual(status.ptr::Ptr{Cvoid}, res::Ref{Cdouble})::Cint
+    return res[]
+end
+
+function status_GetDone(status::Union{StepStatus, AccessStatus})
+    done = Ref{Cint}()
+    @ccall libbraid.braid_StatusGetDone(status.ptr::Ptr{Cvoid}, done::Ref{Cint})::Cint
+    return (done[] > 0)
+end
+
+function status_GetTILD(status::Union{StepStatus, AccessStatus})
+    time = Ref{Cdouble}()
+    iter = Ref{Cint}()
+    level = Ref{Cint}()
+    done = Ref{Cint}()
+    @ccall libbraid.braid_StatusGetTILD(status.ptr::Ptr{Cvoid}, time::Ref{Cdouble}, iter::Ref{Cint}, level::Ref{Cint}, done::Ref{Cint})::Cint
+    return time[], iter[], level[], (done[] > 0)
+end
+
+function status_GetCallingFunction(status::Union{StepStatus, AccessStatus})
+    func = Ref{Cint}()
+    @ccall libbraid.braid_StatusGetCallingFunction(status.ptr::Ptr{Cvoid}, func::Ref{Cint})::Cint
+    return func[]
+end
+
+function status_GetTol(status::StepStatus)
+    tol = Ref{Cdouble}()
+    @ccall libbraid.braid_StatusGetTol(status.ptr::Ptr{Cvoid}, tol::Ref{Cdouble})::Cint
+    return tol[]
+end
+
+function status_GetRNorms(status::StepStatus)
+    iters = status_GetIter(status)
+    nrequest = Ref{Cint}(iters)
+    norms = zeros(Cdouble, iters)
+    @ccall libbraid.braid_StatusGetRNorms(status.ptr::Ptr{Cvoid}, nrequest::Ref{Cint}, norms::Ref{Cdouble})::Cint
+    return norms
+end
+
+function status_GetProc(status::Union{StepStatus, AccessStatus})
+    proc = Ref{Cint}()
+    @ccall libbraid.braid_StatusGetProc(status.ptr::Ptr{Cvoid}, proc::Ref{Cint})::Cint
+    return proc[]
+end
+
+function status_GetDeltaRank(status::Union{StepStatus, AccessStatus})
+    rank = Ref{Cint}()
+    @ccall libbraid.braid_StatusGetDeltaRank(status.ptr::Ptr{Cvoid}, rank::Ref{Cint})::Cint
+    return rank[]
+end
+
+# These are special cases
+function status_GetLocalLyapExponents(status::AccessStatus)
+    rank = status_GetDeltaRank(status)
+    rank < 1 && return []
+
+    exps = zeros(rank)
+    num_retrieved = Ref(rank)
+    @ccall  libbraid.braid_StatusGetLocalLyapExponents(status.ptr::Ptr{Cvoid}, exps::Ref{Cdouble}, num_retrieved::Ref{Cint})::Cint
+    return exps
+end
+
+function status_GetBasisVectors(status::Union{StepStatus, AccessStatus})
+    rank = status_GetDeltaRank(status)
+    Ψ = []
+    rank < 1 && return Ψ
+
+    for i in 1:rank
+        pp = malloc_null_double_ptr(Cvoid)
+        GC.@preserve pp begin
+            @ccall libbraid.braid_StatusGetBasisVec(status.ptr::Ptr{Cvoid}, pp::Ptr{Ptr{Cvoid}}, (i-1)::Cint)::Cint
+        end
+        p = unsafe_load(pp)
+        if p !== C_NULL
+            φ = unsafe_pointer_to_objref(p)::BraidVector
+            push!(Ψ, φ.user_vector)
+        end
+        Base.Libc.free(pp)
+    end
+
+    return Ψ
+end
+
+function status_SetRFactor(status::StepStatus, rfactor::Real)
+    @ccall libbraid.braid_StatusSetRFactor(status.ptr::Ptr{Cvoid}, rfactor::Cdouble)::Cint
+end

--- a/braid/braid.jl/wrapper_functions.jl
+++ b/braid/braid.jl/wrapper_functions.jl
@@ -1,0 +1,310 @@
+#=BHEADER**********************************************************************
+ * Copyright (c) 2013, Lawrence Livermore National Security, LLC. 
+ * Produced at the Lawrence Livermore National Laboratory.
+ * 
+ * This file is part of XBraid. For support, post issues to the XBraid Github page.
+ * 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free Software
+ * Foundation) version 2.1 dated February 1999.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the terms and conditions of the GNU General Public
+ * License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ ***********************************************************************EHEADER=#
+
+"""
+Displays a caught error message, including stacktrace, without throwing
+"""
+function stacktrace_warn(msg::String, err)
+    err_msg = sprint(showerror, err)
+    trace = sprint((io,v) -> show(io, "text/plain", v), stacktrace(catch_backtrace()))
+    @warn "$(msg):\n$(err_msg)\n$(trace)"
+end
+
+"""
+Where'd all my data go?
+This extends Base to include a buffer which throws away the data written to it
+(useful for measuring the serialized size of an object)
+"""
+mutable struct BlackHoleBuffer <: IO
+    ptr::Int
+end
+BlackHoleBuffer() = BlackHoleBuffer(0)
+
+function Base.read(from::BlackHoleBuffer, T::Type{UInt8})
+    throw(ArgumentError("BlackHoleBuffer is not readable)"))
+end
+function Base.write(to::BlackHoleBuffer, x::UInt8)
+    to.ptr += 1
+    return 1
+end
+function Base.write(to::BlackHoleBuffer, x::Array{T}) where T
+    to.ptr += sizeof(x)
+    return sizeof(x)
+end
+
+# these are internal functions which directly interface with XBraid
+
+function _jl_step!(_app::Ptr{Cvoid},
+                   _ustop::Ptr{Cvoid},
+                   _fstop::Ptr{Cvoid},
+                   _u::Ptr{Cvoid},
+                   _status::Ptr{Cvoid})::Cint
+    # println("step")
+    app = unsafe_pointer_to_objref(_app)::BraidApp
+    u = unsafe_pointer_to_objref(_u)::BraidVector
+    ustop = unsafe_pointer_to_objref(_ustop)::BraidVector
+    status = StepStatus(_status)
+
+    tstart, tstop = status_GetTstartTstop(status)
+    delta_rank = status_GetDeltaRank(status)
+
+    # call the user's function
+    try
+        # residual option
+        if _fstop !== C_NULL
+            fstop = unsafe_pointer_to_objref(_fstop)::BraidVector
+            app.step(app.user_app, status, u.user_vector, ustop.user_vector, fstop.user_vector, tstart, tstop)
+        # Delta correction
+        elseif delta_rank > 0
+            basis_vecs = status_GetBasisVectors(status)
+            app.step(app.user_app, status, u.user_vector, ustop.user_vector, tstart, tstop, basis_vecs)
+        # Default
+        else
+            app.step(app.user_app, status, u.user_vector, ustop.user_vector, tstart, tstop)
+        end
+    catch err
+        stacktrace_warn("Error in user Step", err)
+    end
+
+    return 0
+end
+precompile(_jl_step!, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}))
+_c_step = @cfunction(_jl_step!, Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}))
+
+
+function _jl_init!(_app::Ptr{Cvoid}, t::Cdouble, u_ptr::Ptr{Ptr{Cvoid}})::Cint
+    # println("init")
+    app = unsafe_pointer_to_objref(_app)::BraidApp
+    # initialize u and register a reference with IdDict
+    u = nothing
+    try
+        u = BraidVector(app.init(app.user_app, t))
+    catch err
+        stacktrace_warn("Error in user Init", err)
+        return 1
+    end
+    _register_vector(app, u)
+
+    unsafe_store!(u_ptr, pointer_from_objref(u))
+
+    # store max size of all initialized vectors
+    if app.bufsize == 0
+        # This serializes u but doesn't actually
+        # store the data
+        buffer = BlackHoleBuffer()
+        serialize(buffer, u)
+        app.bufsize = buffer.ptr + sizeof(Int)
+    end
+
+    if app.user_VecType == Nothing
+        app.user_VecType = u.VecType
+    end
+
+    # TODO: figure out how to put an upper bound on the size of the serialized object
+    # without serializing it first
+    # u_size = Base.summarysize(Ref(u)) + 9
+    # if u_size > app.bufsize
+    #     app.bufsize = u_size
+    # end
+
+    return 0
+end
+_c_init = @cfunction(_jl_init!, Cint, (Ptr{Cvoid}, Cdouble, Ptr{Ptr{Cvoid}}))
+
+function _jl_init_basis!(_app::Ptr{Cvoid}, t::Cdouble, index::Cint, u_ptr::Ptr{Ptr{Cvoid}})::Cint
+    # println("init_basis")
+    app = unsafe_pointer_to_objref(_app)::BraidApp
+    u = nothing
+    try
+        u = BraidVector(app.basis_init(app.user_app, t, index))
+    catch err
+        stacktrace_warn("Error in user InitBasis", err)
+        return 1
+    end
+
+    _register_vector(app, u)
+    unsafe_store!(u_ptr, pointer_from_objref(u))
+
+    # store max size of all initialized vectors
+    if app.bufsize == 0
+        buffer = BlackHoleBuffer()
+        serialize(buffer, u)
+        app.bufsize_lyap = buffer.ptr + sizeof(Int)
+    end
+
+    # store type of initialized vector
+    if app.user_BasType == Nothing
+        app.user_BasType = u.VecType
+    end
+
+    return 0
+end
+_c_init_basis = @cfunction(_jl_init_basis!, Cint, (Ptr{Cvoid}, Cdouble, Cint, Ptr{Ptr{Cvoid}}))
+
+function _jl_clone!(_app::Ptr{Cvoid}, _u::Ptr{Cvoid}, v_ptr::Ptr{Ptr{Cvoid}})::Cint
+    # println("clone")
+    app = unsafe_pointer_to_objref(_app)::BraidApp
+    u = unsafe_pointer_to_objref(_u)::BraidVector
+    # initialize v, and copy u into v
+    v = nothing
+    try
+        v = deepcopy(u)
+    catch err
+        stacktrace_warn("Clone error", err)
+        return 1
+    end
+
+    # then register v with IdDict and store in v_ptr
+    _register_vector(app, v)
+    unsafe_store!(v_ptr, pointer_from_objref(v))
+
+    return 0
+end
+precompile(_jl_clone!, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Ptr{Cvoid}}))
+_c_clone = @cfunction(_jl_clone!, Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Ptr{Cvoid}}))
+
+function _jl_free!(_app::Ptr{Cvoid}, _u::Ptr{Cvoid})::Cint
+    # println("free")
+    app = unsafe_pointer_to_objref(_app)::BraidApp
+    u = unsafe_pointer_to_objref(_u)::BraidVector
+    # removing the global reference to u will cause it to be garbage collected
+    _deregister_vector(app, u)
+    return 0
+end
+precompile(_jl_free!, (Ptr{Cvoid}, Ptr{Cvoid}))
+_c_free = @cfunction(_jl_free!, Cint, (Ptr{Cvoid}, Ptr{Cvoid}))
+
+function _jl_sum!(_app::Ptr{Cvoid},
+    alpha::Cdouble, _x::Ptr{Cvoid},
+    beta::Cdouble, _y::Ptr{Cvoid})::Cint
+    app = unsafe_pointer_to_objref(_app)::BraidApp
+    x = unsafe_pointer_to_objref(_x)::BraidVector
+    y = unsafe_pointer_to_objref(_y)::BraidVector
+    try
+        app.sum(app.user_app, alpha, x.user_vector, beta, y.user_vector)
+    catch err
+        stacktrace_warn("Error in user Sum", err)
+    end
+    return 0
+end
+precompile(_jl_sum!, (Ptr{Cvoid}, Cdouble, Ptr{Cvoid}, Cdouble, Ptr{Cvoid}))
+_c_sum = @cfunction(_jl_sum!, Cint, (Ptr{Cvoid}, Cdouble, Ptr{Cvoid}, Cdouble, Ptr{Cvoid}))
+
+function _jl_norm!(_app::Ptr{Cvoid}, _u::Ptr{Cvoid}, norm_ptr::Ptr{Cdouble})::Cint
+    app = unsafe_pointer_to_objref(_app)::BraidApp
+    u = unsafe_pointer_to_objref(_u)::BraidVector
+    norm = NaN
+    try
+        norm = app.spatialnorm(app.user_app, u.user_vector)
+    catch err
+        stacktrace_warn("Error in user Norm", err)
+    end
+    unsafe_store!(norm_ptr, norm)
+
+    return 0
+end
+precompile(_jl_norm!, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cdouble}))
+_c_norm = @cfunction(_jl_norm!, Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cdouble}))
+
+function _jl_inner_prod!(_app::Ptr{Cvoid}, _u::Ptr{Cvoid}, _v::Ptr{Cvoid}, norm_ptr::Ptr{Cdouble})::Cint
+    app = unsafe_pointer_to_objref(_app)::BraidApp
+    u = unsafe_pointer_to_objref(_u)::BraidVector
+    v = unsafe_pointer_to_objref(_v)::BraidVector
+    prod = NaN
+    try
+        prod = app.inner_prod(app.user_app, u.user_vector, v.user_vector)
+    catch err
+        stacktrace_warn("Error in user InnerProd", err)
+    end
+    unsafe_store!(norm_ptr, prod)
+
+    return 0
+end
+precompile(_jl_inner_prod!, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cdouble}))
+_c_inner_prod = @cfunction(_jl_inner_prod!, Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cdouble}))
+
+function _jl_access!(_app::Ptr{Cvoid}, _u::Ptr{Cvoid}, _status::Ptr{Cvoid})::Cint
+    app = unsafe_pointer_to_objref(_app)::BraidApp
+    status = AccessStatus(_status)
+
+    if !isnothing(app.access)
+        u = unsafe_pointer_to_objref(_u)::BraidVector
+        try
+            app.access(app.user_app, status, u.user_vector)
+        catch err
+            stacktrace_warn("Error in user Access", err)
+        end
+    end
+
+    return 0
+end
+precompile(_jl_access!, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}))
+_c_access = @cfunction(_jl_access!, Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}))
+
+function _jl_bufsize!(_app::Ptr{Cvoid}, size_ptr::Ptr{Cint}, status::Ptr{Cvoid})::Cint
+    app = unsafe_pointer_to_objref(_app)
+    unsafe_store!(size_ptr, app.bufsize)
+    return 0
+end
+_c_bufsize = @cfunction(_jl_bufsize!, Cint, (Ptr{Cvoid}, Ptr{Cint}, Ptr{Cvoid}))
+
+function _jl_bufpack!(_app::Ptr{Cvoid}, _u::Ptr{Cvoid}, _buffer::Ptr{Cvoid}, status::Ptr{Cvoid})::Cint
+    app = unsafe_pointer_to_objref(_app)::BraidApp
+    u = unsafe_pointer_to_objref(_u)::BraidVector
+    buff_arr = unsafe_wrap(Vector{UInt8}, Base.unsafe_convert(Ptr{UInt8}, _buffer), app.bufsize)
+    buffer = IOBuffer(buff_arr, read=true, write=true, maxsize=app.bufsize)
+
+    # store u in buffer
+    seek(buffer, sizeof(Int))
+    serialize(buffer, u)
+
+    # also store the total size of the buffer
+    seek(buffer, 0)
+    write(buffer, buffer.size)
+
+    # tell braid the written size
+    @ccall libbraid.braid_BufferStatusSetSize(status::Ptr{Cvoid}, buffer.size::Cdouble)::Cint
+
+    return 0
+end
+precompile(_jl_bufpack!, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}))
+_c_bufpack = @cfunction(_jl_bufpack!, Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}))
+
+function _jl_bufunpack!(_app::Ptr{Cvoid}, _buffer::Ptr{Cvoid}, u_ptr::Ptr{Ptr{Cvoid}}, status::Ptr{Cvoid})::Cint
+    @assert _buffer !== C_NULL "tried to unpack null buffer"
+    app = unsafe_pointer_to_objref(_app)::BraidApp
+    # get size of buffer we are unpacking:
+    header = reinterpret(Ptr{Int}, _buffer)
+    bufsize = unsafe_load(header)::Int
+    buff_arr = unsafe_wrap(Vector{UInt8}, Base.unsafe_convert(Ptr{UInt8}, _buffer), bufsize)
+    buffer = IOBuffer(buff_arr, read=true, write=true, maxsize=bufsize)
+    seek(buffer, sizeof(Int))
+
+    # unpack the buffer into a new julia object, then register with IdDict
+    u = deserialize(buffer)::BraidVector{app.user_VecType}
+    _register_vector(app, u)
+
+    # store u in provided pointer
+    unsafe_store!(u_ptr, pointer_from_objref(u))
+    return 0
+end
+precompile(_jl_bufunpack!, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Ptr{Cvoid}}, Ptr{Cvoid}))
+_c_bufunpack = @cfunction(_jl_bufunpack!, Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Ptr{Cvoid}}, Ptr{Cvoid}))

--- a/braid/braid_test.h
+++ b/braid/braid_test.h
@@ -146,6 +146,32 @@ braid_TestInnerProd( braid_App              app,        /**< User defined App st
                      braid_PtFcnInnerProd   inner_prod  /**< Compute inner product of two braid_Vectors */
                      );
               
+
+
+/**
+ * Test the inner_prod function.\n
+ * A vector is initialized at time *t1*, then the vector is normalized under the
+ * norm induced by inner_prod. A second vector is initialized at time *t2*, and the
+ * Gram Schmidt process removes the component of the second vector along the 
+ * direction of the first. The test is inconclusive unless both vectors are nonzero 
+ * and not orthogonal.
+ *
+ * - Returns 0 if the tests fail
+ * - Returns 1 if the tests pass
+ * - Check the log messages to see details of which tests failed.
+ **/
+braid_Int
+braid_TestInnerProd( braid_App              app,        /**< User defined App structure */
+                     MPI_Comm               comm_x,     /**< Spatial communicator */  
+                     FILE                  *fp,         /**< File pointer (could be stdout or stderr) for log messages */
+                     braid_Real             t1,         /**< Time value used to initialize the 1st vector */
+                     braid_Real             t2,         /**< Time value used to initialize the 2nd vector (t1 != t2) */
+                     braid_PtFcnInit        init,       /**< Initialize a braid_Vector on finest temporal grid */
+                     braid_PtFcnFree        free,       /**< Free a braid_Vector */
+                     braid_PtFcnSum         sum,        /**< Compute vector sum of two braid_Vectors */ 
+                     braid_PtFcnInnerProd   inner_prod  /**< Compute inner product of two braid_Vectors */
+                     );
+              
 /**
  * Test the BufPack, BufUnpack and BufSize functions.\n
  * A vector is initialized at time *t*, packed into a buffer, then unpacked from a buffer.
@@ -282,6 +308,32 @@ braid_TestDelta(braid_App               app,          /**< User defined App stru
                 braid_PtFcnStep         mystep        /**< Compute a time step with a braid_Vector */
                 );
 
+/**
+ * Warmup calls all user functions once with sensible arguments.
+ * This is especially useful for the Julia wrapper, since Julia is JIT compiled,
+ * and this force compiles all the functions used in braid_Drive.
+ */
+braid_Int
+braid_Warmup( braid_App                app,         /**< User defined App structure */
+              MPI_Comm                 comm_x,      /**< Spatial communicator */
+              braid_Real               t,           /**< Time value to initialize test vectors with*/
+              braid_Real               fdt,         /**< Fine time step value that you spatially coarsen from */
+              braid_Real               cdt,         /**< Coarse time step value that you coarsen to */
+              braid_PtFcnInit          init,        /**< Initialize a braid_Vector on finest temporal grid*/
+              braid_PtFcnAccess        access,      /**< Allows access to XBraid and current braid_Vector (can be NULL for no writing)*/
+              braid_PtFcnFree          free,        /**< Free a braid_Vector*/
+              braid_PtFcnClone         clone,       /**< Clone a braid_Vector */
+              braid_PtFcnSum           sum,         /**< Compute vector sum of two braid_Vectors */
+              braid_PtFcnSpatialNorm   spatialnorm, /**< Compute norm of a braid_Vector, this is a norm only over space */
+              braid_PtFcnBufSize       bufsize,     /**< Computes size in bytes for one braid_Vector MPI buffer */
+              braid_PtFcnBufPack       bufpack,     /**< Packs MPI buffer to contain one braid_Vector */
+              braid_PtFcnBufUnpack     bufunpack,   /**< Unpacks MPI buffer into a braid_Vector */
+              braid_PtFcnSCoarsen      coarsen,     /**< Spatially coarsen a vector. If NULL, skipped.*/
+              braid_PtFcnSRefine       refine,      /**< Spatially refine a vector. If NULL, skipped.*/
+              braid_PtFcnStep          step,        /**< Compute a time step with a braid_Vector */
+              braid_PtFcnInitBasis     init_basis,  /**< Initialize a basis vector at time t and spatial index i. If NULL, skipped */
+              braid_PtFcnInnerProd     innerprod    /**< Compute the inner product between two braid_Vectors. If NULL, skipped. */
+              );
 /** @}*/
 
 #ifdef __cplusplus

--- a/drivers/julia/drive-TaylorGreen.jl
+++ b/drivers/julia/drive-TaylorGreen.jl
@@ -1,0 +1,329 @@
+using ForwardDiff, DiffResults, LinearAlgebra, PreallocationTools
+using IterativeSolvers, LinearMaps, SparseArrays, Interpolations
+using MPI, BenchmarkTools
+using Plots
+
+include("../../braid/braid.jl/XBraid.jl")
+using .XBraid
+
+MPI.Init()
+comm = MPI.COMM_WORLD
+
+Float = Float64
+
+"""
+struct to package preallocated caches for storing temp coords and velocity
+as well as the sparse poisson matrix needed by project_incompressible!()
+"""
+struct TGApp
+	x_d::DiffCache
+	u_d::DiffCache
+	ϕ_d::DiffCache
+	Δ_s::SparseMatrixCSC
+	solution
+	lyapunov_vecs
+	lyapunov_exps
+	times
+end
+
+# default constructor
+function TGApp(x::AbstractArray, u::AbstractArray, ϕ::AbstractArray, Δ::SparseMatrixCSC)
+	TGApp(DiffCache(x), DiffCache(u), DiffCache(ϕ), Δ, [], [], [], [])
+end
+
+"""
+reshapes 1D array into vector of 3D arrays, with no allocation
+"""
+function get_views(u)
+	@views begin
+		u_x = reshape(u[1:nₓ^3], (nₓ, nₓ, nₓ))
+		u_y = reshape(u[nₓ^3+1:2*nₓ^3], (nₓ, nₓ, nₓ))
+		u_z = reshape(u[2*nₓ^3+1:end], (nₓ, nₓ, nₓ))
+	end
+	return [u_x, u_y, u_z]
+end
+
+# some helpers for doing modulo arithmetic with CartesianIndex
+Base.mod1(I::CartesianIndex, J::CartesianIndex) = CartesianIndex(broadcast(mod1, Tuple(I), Tuple(J)))
+δ(I::CartesianIndex{N}, dim) where N = CartesianIndex(ntuple(i -> i == dim ? 1 : 0, N))
+
+function TaylorGreen!(u, k = 1)
+	kx = trunc(Int64, k/2) + k%2
+	ky = trunc(Int64, k/2) + 1
+	kz = trunc(Int64, k/2) + 1
+	u_x, u_y, u_z = u
+	x, y, z = coordinates
+	@. u_x = sin(kx * x) * cos(ky * y) * cos(kz * z)
+	@. u_y = -cos(kx * x) * sin(ky * y) * cos(kz * z)
+	@. u_z = 0.0
+	return
+end
+
+"""
+finite difference approx first derivative
+of A wrt dimension *dim*
+"""
+function ∂(A, dim; h = Δx)
+	# This works for A of arbitrary dimension
+	out = similar(A)
+    R = CartesianIndices(A)
+    bound = last(R)
+	@views @inbounds for I ∈ R
+		# second order
+		I⁻ = mod1(I - δ(I, dim), bound)
+		I⁺ = mod1(I + δ(I, dim), bound)
+		out[I] = 1 / 2h * (A[I⁺] - A[I⁻])
+	end
+	return out
+end
+
+# divergence, curl, gradient, and laplacian
+∇_dot(V) = 
+sum(enumerate(V)) do (i, V_i)
+    ∂(V_i, i)
+end
+
+function ∇X(V)
+	out_arr = zeros(3 * nₓ^3)
+	out = get_views(out_arr)
+	Vx, Vy, Vz = V
+	x, y, z = 1:3
+	out[x] .= ∂(Vz, y) - ∂(Vy, z)
+	out[y] .= ∂(Vx, z) - ∂(Vz, x)
+	out[z] .= ∂(Vy, x) - ∂(Vx, y)
+	return out
+end
+
+∇(F) = [∂(F, i) for i ∈ 1:3]
+# Δ(F) = ∇_dot(∇(F)) # this is asymmetric...
+
+function my_poisson(f_arr)
+	out_arr = similar(f_arr)
+	F = reshape(f_arr, (nₓ, nₓ, nₓ))
+	out = reshape(out_arr, (nₓ, nₓ, nₓ))
+	R = CartesianIndices(F)
+	bound = last(R)
+	@inbounds for I ∈ R
+		out[I] = -6 * F[I]
+		@inbounds for dim ∈ 1:3
+			I⁺ = mod1(I + δ(I, dim), bound)
+			I⁻ = mod1(I - δ(I, dim), bound)
+			out[I] += F[I⁺] + F[I⁻]
+		end
+		out[I] *= 1 / Δx^2
+	end
+	# need a single point condition u(0,0,0) = 0., else
+	# this system is singular (ones(nₓ^3) nullspace)
+	out[first(R)] += F[first(R)]
+	return out_arr
+end
+
+function my_poisson_mat(nₓ)
+	flat_index(I::CartesianIndex) = I[1] + (I[2] - 1) * nₓ + (I[3] - 1) * nₓ^2
+	rowinds = Array{Int}([])
+	colinds = Array{Int}([])
+	nzs = Array{Float}([])
+	function make_connection!(I_r, I_c, nz)
+		push!(rowinds, flat_index(I_r))
+		push!(colinds, flat_index(I_c))
+		push!(nzs, nz)
+	end
+	diag = -6 / Δx^2
+	offd = 1 / Δx^2
+	bound = CartesianIndex((nₓ, nₓ, nₓ))
+	for I in CartesianIndices((1:nₓ, 1:nₓ, 1:nₓ))
+		make_connection!(I, I, diag)
+		for dim ∈ 1:3
+			I⁺ = mod1(I + δ(I, dim), bound)
+			I⁻ = mod1(I - δ(I, dim), bound)
+			make_connection!(I, I⁺, offd)
+			make_connection!(I, I⁻, offd)
+		end
+	end
+	# point condition u(0,0,0) = 0., else system is singular
+	nzs[1] += 1.0
+	return sparse(rowinds, colinds, nzs)
+end
+
+"""
+compute self advection of u
+"""
+function advect_semi_lagrangian!(app::TGApp, u_arr, Δt)
+	# get cached arrays (either real or dual, depending on typeof(u))
+	coords_new_arr = get_tmp(app.x_d, u_arr)
+	u_new_arr = get_tmp(app.u_d, u_arr)
+
+	u = get_views(u_arr)
+	u_new = get_views(u_new_arr)
+
+	# (1) trace each grid point backwards along u
+	@. coords_new_arr = coords_arr - Δt * u_arr
+	coords_new = get_views(coords_new_arr)
+
+	# (2) interpolate the velocity field at the new grid points
+	x_range = range(0., 2π - Δx, nₓ)
+	for i in 1:3
+		itp = interpolate(u[i], BSpline(Linear(Periodic())))
+		sitp = scale(itp, x_range, x_range, x_range)
+		extp = extrapolate(sitp, Periodic())
+
+		u_new[i] .= extp.(coords_new...)
+	end
+	u_arr .= u_new_arr
+	return u_arr
+end
+
+"""
+Solve Poisson problem for incompressible velocity
+Δϕ = ∇⋅u
+u = u - ∇ϕ
+"""
+function project_incompressible!(app::TGApp, u_arr)
+	u = get_views(u_arr)
+	ϕ_arr = get_tmp(app.ϕ_d, u_arr)
+	ϕ_arr .= 0.
+	rhs = vec(∇_dot(u))
+	cg!(ϕ_arr, app.Δ_s, rhs; abstol=1/2*Δx^2)
+	# cg!(ϕ_arr, app.Δ_s, rhs)
+
+	ϕ = reshape(ϕ_arr, (nₓ, nₓ, nₓ))
+	for i in 1:3
+		u[i] .-= ∂(ϕ, i)
+	end
+	return u_arr
+end
+
+function base_step(app::TGApp, u_arr, Δt)
+	# print("Advection : ")
+	advect_semi_lagrangian!(app, u_arr, Δt)
+	# diffuse_backward_Euler!(u_arr, Δt) # numerical diffusion may be enough
+	# print("Projection: ")
+	project_incompressible!(app, u_arr)
+	return u_arr
+end
+
+nₓ = 64
+Δx = 2π / nₓ
+
+function my_init(app, t)
+	u_arr = zeros(Float, 3 * nₓ^3)
+	u = get_views(u_arr)
+	TaylorGreen!(u)
+	return u_arr
+end
+
+function my_basis_init(app, t, i)
+	ψ_arr = zeros(Float, 3 * nₓ^3)
+	ψ = get_views(ψ_arr)
+	TaylorGreen!(ψ, i + 1)
+	ψ_arr .+= Δx^3*randn(Float, 3 * nₓ^3)
+	return ψ_arr
+end
+
+function my_step!(app, status, u, ustop, tstart, tstop)
+	u = base_step(app, u, tstop - tstart)
+	return
+end
+
+function my_step!(app, status, u, ustop, tstart, tstop, Ψ)
+	Δt = tstop - tstart
+	rank = length(Ψ)
+	Ψ_new = reduce(hcat, Ψ)
+	perturb(r) = base_step(app, u + r' * Ψ, Δt)
+
+	result = DiffResults.DiffResult(u, Ψ_new)
+	result = ForwardDiff.jacobian!(result, perturb, zeros(rank))
+	for i in 1:rank
+		Ψ[i] .= Ψ_new[:, i]
+	end
+	return
+end
+
+function my_sum!(app, a, x, b, y)
+	@. y = a * x + b * y
+end
+
+function my_access(app, status, u)
+	index = XBraid.status_GetTIndex(status)
+	lyap_exps = XBraid.status_GetLocalLyapExponents(status)
+	lyap_vecs = XBraid.status_GetBasisVectors(status)
+	if length(lyap_vecs) > 0
+		push!(app.lyapunov_vecs, deepcopy(reduce(hcat, lyap_vecs)))
+		push!(app.lyapunov_exps, lyap_exps)
+	end
+
+	push!(app.solution, deepcopy(u))
+	push!(app.times, index)
+end
+
+my_norm(app, u) = Δx^3 * LinearAlgebra.norm2(u)
+my_innerprod(app, u, v) = u' * v
+
+coords_arr = zeros(Float, 3 * nₓ^3)
+coordinates = get_views(coords_arr)
+x_bound = 2π - Δx
+x_range = range(0, x_bound, nₓ)
+coordinates[1] .= [x for x ∈ x_range, y ∈ x_range, z ∈ x_range]
+coordinates[2] .= [y for x ∈ x_range, y ∈ x_range, z ∈ x_range]
+coordinates[3] .= [z for x ∈ x_range, y ∈ x_range, z ∈ x_range];
+
+function test()
+	# preallocations
+	x_d = zeros(Float, 3 * nₓ^3)
+	u_d = zeros(Float, 3 * nₓ^3)
+	ϕ_d = zeros(Float, nₓ^3)
+	Δ = my_poisson_mat(nₓ)
+	my_app = TGApp(x_d, u_d, ϕ_d, Δ)
+
+	# test user routines:
+	test_app = XBraid.BraidApp(
+		my_app, comm, comm,
+		my_step!, my_init,
+		my_sum!, my_norm, my_access,
+		my_basis_init, my_innerprod)
+
+	XBraid.testInitAccess(test_app, 0.0)
+	XBraid.testClone(test_app, 0.0)
+	XBraid.testSpatialNorm(test_app, 0.0)
+	XBraid.testBuf(test_app, 0.0)
+	@time XBraid.testDelta(test_app, 0.0, 0.1, 3)
+
+	curlz = ∇X(get_views(my_app.solution[1]))[3]
+	heatmap(curlz[:, :, 1])
+end
+
+function main(;ml=1, tstop=4., ntime=32, delta_rank=0)
+	# preallocations
+	x_d = zeros(Float, 3 * nₓ^3)
+	u_d = zeros(Float, 3 * nₓ^3)
+	ϕ_d = zeros(Float, nₓ^3)
+	Δ = my_poisson_mat(nₓ)
+	my_app = TGApp(x_d, u_d, ϕ_d, Δ)
+
+	# theme(:dracula)
+	tstart = 0.0
+
+	core = XBraid.Init(
+		comm, comm, tstart, tstop, ntime,
+		my_step!, my_init, my_sum!, my_norm, my_access; app = my_app,
+	)::XBraid.BraidCore
+
+	if delta_rank > 0
+		XBraid.SetDeltaCorrection(core, delta_rank, my_basis_init, my_innerprod)
+		XBraid.SetLyapunovEstimation(core; exponents=true)
+	end
+	XBraid.SetMaxLevels(core, ml)
+	XBraid.SetMaxIter(core, 10)
+	XBraid.SetCFactor(core, -1, 2)
+	XBraid.SetAccessLevel(core, 1)
+	XBraid.SetNRelax(core, -1, 0)
+	XBraid.SetAbsTol(core, 1e-6)
+
+	@time XBraid.Drive(core)
+
+	p = sortperm(my_app.times)
+	curlz_start = ∇X(get_views(my_app.solution[p][1]))[3]
+	curlz_end = ∇X(get_views(my_app.solution[p][end]))[3]
+	plot(heatmap(curlz_start[1, :, :]), heatmap(curlz_end[1, :, :]), size=(900,400))
+	return my_app
+end

--- a/drivers/julia/drive-advdiff-theta.jl
+++ b/drivers/julia/drive-advdiff-theta.jl
@@ -1,0 +1,151 @@
+using ToeplitzMatrices, LinearAlgebra
+using Plots
+using MPI
+using IterativeSolvers
+
+include("../../braid/braid.jl/XBraid.jl")
+using .XBraid
+
+struct AdvDifApp
+    nx::Int
+    Δx::Float64
+    A::Circulant
+    I::SymmetricToeplitz
+    useTheta::Bool
+    useRich::Bool
+    cf::Int
+    order::Int
+    solTf::Vector{Vector{Float64}}
+    residuals::Vector{Float64}
+end
+# default constructor
+function AdvDifApp(nx::Integer, Δx::Real, ν::Real, α::Real, useTheta::Bool, useRich::Bool, cf::Integer, order::Integer) 
+    I = SymmetricToeplitz([1, zeros(nx-1)...])
+    # Δ = (1/Δx^2)SymmetricToeplitz([-2, 1, zeros(nx-2)...])
+    # ∇ = (1/Δx)Toeplitz([0, -1/2, zeros(nx-2)...], [0, 1/2, zeros(nx-2)...])
+    Δ = (1/Δx^2)Circulant([-2, 1, zeros(nx-3)..., 1])
+    ∇ = (1/Δx)Circulant([0, -1/2, zeros(nx-3)..., 1/2])
+    # ∇ = (1/Δx)Circulant([-1, 1, zeros(nx-2)...])
+    A = ν*Δ - α*∇
+    AdvDifApp(nx, Δx, A, I, useTheta, useRich, cf, order, [], [])
+end
+
+function my_init(app, t)
+    t == 0.0 && return sin.(range(0., 2π-app.Δx, app.nx))
+    return randn(app.nx)
+end
+
+function backward_euler!(app, u, Δt)
+    u .= (app.I - Δt * app.A) \ u
+    # u .= cg(app.I - Δt * app.A, u)
+    return u
+end
+
+function θ_euler!(app, u, Δt, m)
+    θ = (m - 1)/2m
+    u .= (app.I - (1-θ)Δt * app.A) \ ((app.I + θ*Δt * app.A) * u)
+    return u
+end
+
+function SDIRK2!(app, u, Δt)
+    a = 1/√2
+    k1 = Δt*((app.I - (1-a) * Δt * app.A) \ (app.A*u))
+    k2 = Δt*((app.I - (1-a) * Δt * app.A) \ (app.A*(u + (2a-1)*k1)))
+    u .+= 1/2*(k1 + k2)
+    return u
+end
+
+function θSDIRK2!(app, u, Δt, m)
+    α = √2√(m*(m-1))/2m
+    θ = (m^2 -3m - √2√(m*(m-1)))/(2m^2 - 4m)
+    k1 = Δt*((app.I - (1-α) * Δt * app.A) \ (app.A*u))
+    k2 = Δt*((app.I - (1-α) * Δt * app.A) \ (app.A*(u + (2α-1)*k1)))
+    u .+= (θ)k1 + (1-θ)k2
+    return u
+end
+
+function base_step!(app, u, Δt, level)
+    if app.order == 2
+        if app.useTheta
+            throw("Theta method not implemented for order 2")
+        end
+        return SDIRK2!(app, u, Δt)
+    end
+
+    if app.useTheta && level > 0
+        return θSDIRK2!(app, u, Δt, app.cf^level)
+        # return θ_euler!(app, u, Δt, app.cf^level)
+    end
+
+    return backward_euler!(app, u, Δt)
+end
+
+function my_step!(app, status, u, ustop, tstart, tstop)
+    Δt = tstop - tstart
+    level = XBraid.status_GetLevel(status)
+    if !app.useRich || level == 0
+        return base_step!(app, u, Δt, level)
+    end
+    m = app.cf ^ level
+    p = app.order
+    if app.useTheta
+        p += 1
+    end
+    θ = 2^p * (m^p - 1) / (m^p * (2^p - 1))
+    u_sub = deepcopy(u)
+    base_step!(app, u_sub, Δt/2, level)
+    base_step!(app, u_sub, Δt/2, level)
+    base_step!(app, u, Δt, level)
+    @. u = θ*u_sub + (1-θ)*u
+    return u
+end
+
+function my_access(app, status, u)
+    XBraid.status_GetWrapperTest(status) && return
+    ti = XBraid.status_GetTIndex(status)
+    ntime = XBraid.status_GetNTPoints(status)
+    if ti == ntime
+        push!(app.solTf, deepcopy(u))
+    end
+end
+
+function test(;ν=1., α=1., order=1)
+    MPI.Init()
+    comm = MPI.COMM_WORLD
+
+    my_app = AdvDifApp(512, 2π/513, ν, α, false, false, 2, order)
+    app = XBraid.BraidApp(my_app, comm, my_step!, my_init, my_access)
+
+    XBraid.testInitAccess(app, 0.)
+    XBraid.testSpatialNorm(app, 0.)
+    u = my_init(my_app, 0.)
+    plot(u, label="u0", legend=:bottomright)
+    my_step!(my_app, nothing, u, nothing, 0., .1)
+    plot!(u, label="u1")
+end
+
+
+function main(;tstop=2π, ntime=512, nx=512, ν=1., α=1., useTheta=false, useRich=false, cf=2, ml=2, order=1)
+    MPI.Init()
+    comm = MPI.COMM_WORLD
+
+    Δx = 2π / nx
+    app = AdvDifApp(nx, Δx, ν, α, useTheta, useRich, cf, order)
+
+    core = XBraid.Init(comm, 0.0, tstop, ntime, my_step!, my_init, my_access; app=app)
+
+    XBraid.SetPrintLevel(core, 2)
+    XBraid.SetMaxLevels(core, ml)
+    XBraid.SetCFactor(core, -1, app.cf)
+    XBraid.SetAccessLevel(core, 1)
+    XBraid.SetNRelax(core, -1, 1)
+    XBraid.SetAbsTol(core, 1e-8)
+    XBraid.SetMaxIter(core, 40)
+    XBraid.SetSkip(core, false)
+    
+    XBraid.Drive(core)
+
+    append!(app.residuals, XBraid.GetRNorms(core))
+
+    return app
+end

--- a/drivers/julia/drive-burgers.jl
+++ b/drivers/julia/drive-burgers.jl
@@ -1,0 +1,334 @@
+using LinearAlgebra, PreallocationTools, ForwardDiff, DiffResults
+using MPI, Interpolations, IterativeSolvers
+using SparseArrays, ToeplitzMatrices
+using FFTW
+using Plots
+using LinearAlgebra: norm2
+using Random: seed!
+# theme(:dracula)
+
+include("../../braid/braid.jl/XBraid.jl")
+using .XBraid
+
+MPI.Init()
+comm = MPI.COMM_WORLD
+
+struct BurgerApp
+    x::Vector{Float64}
+    κ::Frequencies{Float64}
+    μ::Float64
+    cf::Int
+    useTheta::Bool
+    # preallocated caches that support ForwardDiff:
+    x_d::DiffCache
+    y_d::DiffCache
+    # storage for solution values
+    solution::Vector{Vector{Float64}}
+    lyap_vecs::Vector{Union{Matrix{Float64}, Vector{Float64}}}
+    lyap_exps::Vector{Vector{Float64}}
+    times::Vector{Int}
+    # pre-planned fourier transform
+    P̂
+end
+
+function BurgerApp(x::Vector{<:Real}, κ::Frequencies{<:Real}, μ::Real, cf::Integer, useTheta::Bool, x_cache::AbstractArray, y_cache::AbstractArray)
+    BurgerApp(x, κ, μ, cf, useTheta, DiffCache(x_cache), DiffCache(y_cache), [], [], [], [], plan_fft(x))
+end
+
+# system parameters (globally scoped)
+const lengthScale = 2π
+const nₓ = 1024
+const Δx = lengthScale / nₓ
+
+function stencil_to_circulant(stencil::Vector{T}, nx::Integer) where T
+    @assert isodd(length(stencil)) "stencil should have odd number of entries"
+    stencilWidth = length(stencil)
+    center = ceil(Int, length(stencil)/2)
+    columnView = @view(stencil[end:-1:1])
+    v = [columnView[center:end]; zeros(T, nx-stencilWidth); columnView[1:center-1]]
+    return Circulant(v)
+end
+
+function euler_mat(Δt::Float64; μ::Float64=.00001)
+    # diffusion
+    # A = spdiagm(-1 => ones(nₓ-1), 0 => -2*ones(nₓ), 1 => ones(nₓ-1))
+    # A[1, end] = 1
+    # A[end, 1] = 1
+    # A = sparse(I, (nₓ, nₓ)) - Δt/Δx^2 * μ * A
+
+    # KS operator
+    ∇⁴ = [1, -4, 6, -4, 1]
+    ∇² = [0, 1, -2, 1, 0]
+    I  = [0, 0, 1, 0, 0]
+    stencil = @. I - Δt*(-1/Δx^4 * ∇⁴ - 1/Δx^2 * ∇²)
+    # stencil = @. I - Δt(-μ/Δx^4 * ∇⁴)
+    stencil_to_circulant(stencil, nₓ)
+end
+
+function semi_lagrangian!(burger::BurgerApp, y, v, Δt)
+    x_back = get_tmp(burger.x_d, y)
+    y_intp = get_tmp(burger.y_d, y)
+
+    # initialize interpolation
+    itp = interpolate(y, BSpline(Linear(Periodic())))
+    sitp = scale(itp, range(0., lengthScale - Δx, nₓ))
+    extp = extrapolate(sitp, Periodic())
+
+    # forward euler
+    x_back .= burger.x .- Δt * v
+
+    # backward euler
+    # max_newton = 1000
+    # av_iters = 0.
+    # for i ∈ eachindex(x_back)
+    #     for iter ∈ 1:max_newton
+    #         p = extp(x_back[i])
+    #         p_prime = Interpolations.gradient(extp, x_back[i])[]
+    #         x_back[i] -= (x_back[i] + Δt * p - burger.x[i]) / (1 + Δt * p_prime)
+    #         if abs(x_back[i] + Δt * p - burger.x[i]) < 1e-10
+    #             # av_iters += iter/nₓ
+    #             break
+    #         end
+    #     end
+    # end
+    # println(av_iters)
+    
+    # y_intp .= interp_periodic.(x_back, Ref(y))
+    y_intp .= extp.(x_back)
+    y .= y_intp
+    return y
+end
+
+function diffuse_beuler!(burger::BurgerApp, y, Δt::Float64; init_guess=nothing)
+    y_tmp = get_tmp(burger.y_d, y)
+    y_tmp .= y
+
+    if init_guess !== nothing
+        y .= init_guess
+    end
+
+    cg!(y, euler_mat(Δt), y_tmp)
+    return y
+end
+
+function diffuse_fft!(burger::BurgerApp, y::AbstractArray, Δt::Real; init_guess=nothing)
+    P̂ = burger.P̂
+    κ = burger.κ
+    # y .= real(P̂ \ (exp.(Δt*(κ.^2 - κ.^4))))
+    ŷ = P̂ * y
+    @. ŷ *= exp(-burger.μ * Δt * κ^2) # standard diffusion
+    # @. ŷ *= exp(Δt*(κ^2 - κ^4)) # KS-equation operator
+    y .= real(P̂ \ ŷ)
+    return y
+end
+
+function extractPartials(y::Vector{ForwardDiff.Dual{T,V,P}}) where {T,V,P}
+    ps = zeros(V, size(y)..., P)
+    for i ∈ eachindex(y), j ∈ 1:P
+        @inbounds ps[i, j] = ForwardDiff.partials(y[i], j)
+    end
+    return ps
+end
+
+function fillDualArray!(y::Vector{ForwardDiff.Dual{T,V,P}}, vs, ps) where {T,V,P}
+    checkbounds(ps, firstindex(y), 1:P)
+    for i ∈ eachindex(y)
+        @inbounds y[i] = ForwardDiff.Dual{T}(vs[i], ntuple(j -> @inbounds(ps[i, j]), P))
+    end
+end
+
+# this enables ForwardDiff through the FFT where it normally doesn't work
+function diffuse_fft!(burger::BurgerApp, y::Vector{ForwardDiff.Dual{T,V,P}}, Δt::Real; μ=1e-4) where {T, V, P}
+    vs = ForwardDiff.value.(y)
+    ps = extractPartials(y)
+    diffuse_fft!(burger, vs, Δt; μ=μ)
+    map(eachcol(ps)) do p diffuse_fft!(burger, p, Δt; μ=μ) end
+    fillDualArray!(y, vs, ps)
+    return y
+end
+
+# user routines:
+function my_init(burger::BurgerApp, t::Float64)
+    # sin
+    u = sin.(2π/lengthScale * burger.x)
+    # gaussian
+    # u = exp.(-(burger.x .- lengthScale/2).^2 / (lengthScale/5)^2)
+    # if t == 0
+    #     seed!(1234)
+    #     u .+= 1e-1randn(nₓ) .* u
+    # end
+    # @. u = exp(-(burger.x - lengthScale/2)^2)
+    return u
+end
+
+function my_basis_init(burger::BurgerApp, t::Float64, k::Int32)
+    x = burger.x
+    ψ = similar(x)
+    if k % 2 == 0
+        @. ψ = cos(k/2*x)
+    else
+        @. ψ = sin((k+1)/2*x)
+    end
+    return ψ
+end
+
+function base_step!(burger::BurgerApp, u, Δt::Float64; init_guess=nothing)
+    u_mid = deepcopy(u)
+    semi_lagrangian!(burger, u_mid, u, Δt/2)
+    semi_lagrangian!(burger, u, u_mid, Δt) # u(∇ u)
+    # semi_lagrangian!(burger, u, sin.(burger.x), Δt) # ∇ u
+    # semi_lagrangian!(burger, u, u, Δt) # u(∇ u)
+    if burger.μ > 0.
+        diffuse_fft!(burger, u, Δt) # Δu
+    end
+end
+
+function my_step!(
+    burger::BurgerApp, status::XBraid.StepStatus,
+    u, ustop, tstart::Float64, tstop::Float64
+)
+    Δt = tstop - tstart
+    level = XBraid.status_GetLevel(status)
+    if !burger.useTheta || level == 0
+        base_step!(burger, u, Δt; init_guess=ustop)
+    else
+        # richardson based θ method
+        m = burger.cf^level
+        θ = 2(m - 1)/m
+        # p = 0.86
+        # p = 1.
+        # θ = 2^p * (m^p - 1) / (m^p * (2^p - 1))
+        # θ = 2
+        u_sub = deepcopy(u)
+        base_step!(burger, u_sub, Δt/2; init_guess=(ustop .- u)./2)
+        base_step!(burger, u_sub, Δt/2; init_guess=ustop)
+        base_step!(burger, u, Δt; init_guess=u_sub)
+        @. u = θ*u_sub + (1-θ)*u
+    end
+    return u
+end
+
+function my_step!(burger::BurgerApp, status::XBraid.StepStatus, u, ustop, tstart::Float64, tstop::Float64, Ψ)
+    rank = length(Ψ)
+    Ψ_new = reduce(hcat, Ψ)
+    # perturb(r) = base_step!(burger, u + r' * Ψ, Δt)
+    perturb(r) = my_step!(burger, status, u + r' * Ψ, ustop, tstart, tstop)
+
+    result = DiffResults.DiffResult(u, Ψ_new)
+    result = ForwardDiff.jacobian!(result, perturb, zeros(rank))
+    for i in eachindex(Ψ)
+        Ψ[i] .= Ψ_new[:, i]
+    end
+end
+
+function my_sum!(burger, a, x, b, y)
+    @. y = a*x + b*y
+end
+
+function my_access(burger::BurgerApp, status::XBraid.AccessStatus, u)
+    XBraid.status_GetWrapperTest(status) && return
+    ti = XBraid.status_GetTIndex(status)
+    push!(burger.solution, deepcopy(u))
+    push!(burger.times, ti)
+    if XBraid.status_GetDeltaRank(status) > 0
+        Ψ = XBraid.status_GetBasisVectors(status)
+        λ = XBraid.status_GetLocalLyapExponents(status)
+        push!(burger.lyap_vecs, deepcopy(reduce(hcat, Ψ)))
+        push!(burger.lyap_exps, deepcopy(λ))
+    end
+end
+
+my_norm(burger, u) = LinearAlgebra.norm2(u)
+my_innerprod(burger, u, v) = u' * v
+
+# test user routines:
+function test()
+    x_new = zeros(nₓ)
+    y_new = zeros(nₓ)
+    x = Array(range(0., lengthScale-Δx, nₓ))
+    κ = 2π/lengthScale .* fftfreq(nₓ, nₓ)
+    burger = BurgerApp(x, κ, 0., 4, false, x_new, y_new);
+    test_app = XBraid.BraidApp(
+        burger, comm, comm,
+        my_step!, my_init,
+        my_sum!, my_norm, my_access,
+        my_basis_init, my_innerprod)
+
+    open("drive-burgers.test.out", "w") do file
+        cfile = Libc.FILE(file)
+        XBraid.testBuf(test_app, 0.0, cfile)
+        XBraid.testSpatialNorm(test_app, 0.0, cfile)
+        XBraid.testDelta(test_app, 0.0, 0.1, 3, cfile)
+    end
+    # plot!(burger.lyap_vecs[1][1])
+    plot(burger.solution[1])
+end
+
+function main(;tstop=π, ntime=128, deltaRank=0, useTheta=false, fmg=false, ml=1, cf=4, saveGif=false, maxiter=30, μ=0.)
+    x_new = zeros(nₓ)
+    y_new = zeros(nₓ)
+    x = Array(range(0., lengthScale-Δx, nₓ))
+    κ = 2π/lengthScale .* fftfreq(nₓ, nₓ)
+    burger = BurgerApp(x, κ, μ, 4, useTheta, x_new, y_new);
+
+    tstart = 0.0
+    core = XBraid.Init(
+        comm, comm, tstart, tstop, ntime,
+        my_step!, my_init, my_sum!, my_norm, my_access; app=burger
+    )
+
+    if deltaRank > 0
+        XBraid.SetDeltaCorrection(core, deltaRank, my_basis_init, my_innerprod)
+        XBraid.SetLyapunovEstimation(core; exponents=true)
+    end
+
+    # println("Wrapper test:")
+    # @time test()
+
+    XBraid.SetMaxIter(core, maxiter)
+    XBraid.SetMaxLevels(core, ml)
+    XBraid.SetCFactor(core, -1, cf)
+    XBraid.SetAccessLevel(core, 1)
+    XBraid.SetNRelax(core, -1, 1)
+    XBraid.SetAbsTol(core, 1e-6)
+    XBraid.SetSkip(core, false)
+    if fmg
+        XBraid.SetFMG(core)
+        XBraid.SetNFMG(core, 1)
+    end
+
+    XBraid.SetTimings(core, 2)
+    XBraid.Warmup(core)
+    XBraid.Drive(core; warmup=false)
+    XBraid.PrintTimers(core)
+
+    if deltaRank > 0
+        exponents = sum(burger.lyap_exps)
+        exponents = MPI.Allreduce(exponents, (+), comm)
+        exponents ./= tstop
+        if MPI.Comm_rank(comm) == 0
+            println("exponents: ", exponents)
+        end
+    end
+
+    if saveGif
+        for (ti, u) in zip(burger.times, burger.solution)
+            plt = plot(burger.x, u; ylim=(-1.5, 1.5))
+            savefig(plt, "burgers_gif/$(lpad(ti, 6, "0")).png")
+        end
+        MPI.Barrier(comm)
+
+        if MPI.Comm_rank(comm) == 0
+            println("animating...")
+            fnames = [lpad(i, 6, "0") for i in 0:ntime]
+            anim = Animation("burgers_gif", fnames)
+            Plots.buildanimation(anim, "burgers_gif/anim.gif", fps=30)
+        end
+    end
+
+    return burger, XBraid.GetRNorms(core)
+end
+
+# test()
+# main();
+nothing

--- a/drivers/julia/drive-kflow.jl
+++ b/drivers/julia/drive-kflow.jl
@@ -1,0 +1,443 @@
+using ForwardDiff, DiffResults, LinearAlgebra, PreallocationTools
+using Interpolations, FFTW
+using MPI, Base.Threads
+using BenchmarkTools, Plots, LaTeXStrings
+using Statistics: mean
+using Random: seed!
+using LinearAlgebra: norm
+
+include("../../braid/braid.jl/XBraid.jl")
+using .XBraid
+
+MPI.Init()
+comm = MPI.COMM_WORLD
+
+Float = Float64
+
+"""
+struct containing everything needed internally for the simulation
+"""
+struct KFlowApp
+	cf::Int
+	useTheta::Bool
+	deltaRank::Int
+	coords::Array{Float, 3}
+	κ::Frequencies{Float}
+	k_num::Int
+	ℜ::Float
+	solution::Vector{Array{Float, 3}}
+	solTf::Vector{Array{Float, 3}}
+	lyapunov_vecs::Vector{Vector{Array{Float, 3}}}
+	lyapunov_exps::Vector{Vector{Float}}
+	times::Vector{Int}
+	x_d::DiffCache{Array{Float, 3}}
+	u_d::DiffCache{Array{Float, 3}}
+	ϕ_d::DiffCache{Array{Complex{Float}, 2}}
+	P̂::FFTW.FFTWPlan
+end
+
+# default constructor
+function KFlowApp(cf::Integer, useTheta::Bool, deltaRank::Integer, k_num::Integer, ℜ::Real)
+	coords = zeros(Float, nₓ, nₓ, 2)
+	x_range = range(0, lengthScale - Δx, nₓ)
+	@views @inbounds for (i, x) ∈ enumerate(x_range), (j, y) ∈ enumerate(x_range)
+		coords[i, j, 1] = x
+		coords[i, j, 2] = y
+	end
+	κ = 2π / lengthScale .* fftfreq(nₓ, nₓ)
+	# preallocations
+	x_d = zeros(Float, nₓ, nₓ, 2)
+	u_d = zeros(Float, nₓ, nₓ, 2)
+	ϕ_d = zeros(Complex{Float}, nₓ, nₓ)
+	KFlowApp(cf, useTheta, deltaRank, coords, κ, k_num, ℜ, [], [], [], [], [], DiffCache(x_d), DiffCache(u_d), DiffCache(ϕ_d), plan_fft(coords, [1, 2]))
+end
+
+oneball(n) = [(n + 1 - i, i) for i ∈ 1:n]
+wavenumbers(shell) = reduce(hcat, [oneball(i) for i ∈ 1:shell])
+is_in_shell(i, shell) = i <= trunc(Int, shell * (shell + 1) / 2)
+
+"""
+compute ith wavenumber for a 2D scalar field
+"""
+function get_wavenumber2D(i)
+	shell = 1
+	for _ ∈ 1:i
+		is_in_shell(i, shell) && break
+		shell += 1
+	end
+	shell_start = trunc(Int, shell * (shell - 1) / 2)
+	rel_i = i - shell_start
+	return oneball(shell)[rel_i]
+end
+
+"""
+compute the ith Fourier mode of a 1D scalar field
+"""
+function fourierMode1D(x::Real, k::Integer)
+	k % 2 == 1 && return cos(trunc(k / 2) * 2π / lengthScale * x)
+	k % 2 == 0 && return sin(trunc((k + 1) / 2) * 2π / lengthScale * x)
+end
+
+"""
+compute the ith Fourier mode of a 2D scalar field
+"""
+function fourierMode2D!(app::KFlowApp, u_field, i::Integer)
+	kx, ky = get_wavenumber2D(i)
+	@views x, y = app.coords[:, :, 1], app.coords[:, :, 2]
+	@. u_field = fourierMode1D(x, kx) * fourierMode1D(y, ky)
+end
+
+"""
+compute the ith Fourier mode of a 2D vector field
+"""
+function fourierMode2DVec!(app::KFlowApp, u, i::Integer)
+	@views ux, uy = u[:, :, 1], u[:, :, 2]
+	kx, ky = get_wavenumber2D(i)
+	fourierMode2D!(app, ux, kx)
+	fourierMode2D!(app, uy, ky)
+end
+
+"""
+set the initial condition to a Taylor-Green vortex
+"""
+function TaylorGreen!(app::KFlowApp, u, k = 1)
+	coords = app.coords
+	kx = trunc(Int, k / 2) + k % 2
+	ky = trunc(Int, k / 2) + 1
+	@views u_x, u_y = u[:, :, 1], u[:, :, 2]
+	@views x, y = coords[:, :, 1], coords[:, :, 2]
+	@. u_x = sin(kx * x) * cos(ky * y)
+	@. u_y = -cos(kx * x) * sin(ky * y)
+	return
+end
+
+"""
+compute the forcing term
+"""
+function kolmogorovForce!(app::KFlowApp, u, Δt; μ = 32.)
+	k = app.k_num
+	# Fₖ(x, y) = (sin(ky), 0)
+	@views @. u[:, :, 1] += μ * Δt * sin(k * app.coords[:, :, 2])
+	return u
+end
+
+"""
+compute self advection of u
+"""
+function advect_semi_lagrangian!(app::KFlowApp, u::AbstractArray, v::AbstractArray, Δt::Real)
+	# get cached arrays (either real or dual, depending on typeof(u))
+	coords_new = get_tmp(app.x_d, u)
+	u_new = get_tmp(app.u_d, u)
+
+	# (1) trace each grid point backwards along u
+	@. coords_new = app.coords - Δt * v
+
+	# (2) interpolate the velocity field at the new grid points
+	x_range = range(0.0, lengthScale - Δx, nₓ)
+	for i in 1:2
+		itp = interpolate(u[:, :, i], BSpline(Linear(Periodic())))
+		sitp = scale(itp, x_range, x_range)
+		extp = extrapolate(sitp, Periodic())
+
+		u_new[:, :, i] .= @views extp.(coords_new[:, :, 1], coords_new[:, :, 2])
+	end
+	u .= u_new
+	return u
+end
+
+"""
+Solve Poisson problem for incompressible velocity field
+Δϕ = ∇⋅u
+u = u - ∇ϕ
+"""
+function project_incompressible!(app::KFlowApp, u::AbstractArray, Δt::Real)
+	κ = get_tmp(app.x_d, u)
+	ϕ = get_tmp(app.ϕ_d, u)
+	P̂ = app.P̂
+	ℜ = app.ℜ
+	for (i, κ_x) ∈ enumerate(app.κ), (j, κ_y) ∈ enumerate(app.κ)
+		κ[i, j, 1] = κ_x
+		κ[i, j, 2] = κ_y
+	end
+	û = P̂ * u
+	@views κ_x, κ_y = κ[:, :, 1], κ[:, :, 2]
+	@views û_x, û_y = û[:, :, 1], û[:, :, 2]
+	# diffusion
+	@. û_x *= exp(-Δt / ℜ * (κ_x^2 + κ_y^2))
+	@. û_y *= exp(-Δt / ℜ * (κ_x^2 + κ_y^2))
+
+	# KS equation: uₜ + u(∇u) = - Δu - Δ²u
+	# @. û_x *= exp(Δt*(κ_x^2 + κ_y^2 - (κ_x^2 + κ_y^2)^2))
+	# @. û_y *= exp(Δt*(κ_x^2 + κ_y^2 - (κ_x^2 + κ_y^2)^2))
+
+	# incompressible projection
+	# ϕ = inv(Δ)∇⋅u
+	@. ϕ = -(1.0im * κ_x * û_x + 1.0im * κ_y * û_y) / (κ_x^2 + κ_y^2)
+	ϕ[1, 1] = 0.0 + 0.0im # pressure is unique up to a constant
+	# u = u - ∇ϕ
+	@. û_x -= 1.0im * κ_x * ϕ
+	@. û_y -= 1.0im * κ_y * ϕ
+
+	u .= real(P̂ \ û)
+	return u
+end
+
+function extractPartials(u::AbstractArray{ForwardDiff.Dual{T, V, P}}) where {T, V, P}
+	ps = zeros(V, size(u)..., P)
+	for I ∈ CartesianIndices(u), j ∈ 1:P
+		@inbounds ps[I, j] = ForwardDiff.partials(u[I], j)
+	end
+	return ps
+end
+
+function fillArrayOfDuals!(u::AbstractArray{ForwardDiff.Dual{T, V, P}}, vs::AbstractArray{V}, ps::AbstractArray{V}) where {T, V, P}
+	checkbounds(ps, first(CartesianIndices(u)), 1:P) # make inbounds safe
+	for I ∈ CartesianIndices(u)
+		@inbounds u[I] = ForwardDiff.Dual{T}(vs[I], ntuple(j -> @inbounds(ps[I, j]), P))
+	end
+end
+
+# this enables ForwardDiff through the FFT where it normally doesn't work
+function project_incompressible!(app::KFlowApp, u::AbstractArray{ForwardDiff.Dual{T, V, P}}, Δt::Real) where {T, V, P}
+	vs = ForwardDiff.value.(u)
+	ps = extractPartials(u)
+	project_incompressible!(app, vs, Δt)
+	map(eachslice(ps, dims = 4)) do p
+		project_incompressible!(app, p, Δt)
+	end
+	fillArrayOfDuals!(u, vs, ps)
+	return u
+end
+
+function ∇_dot(app, u)
+	κ = get_tmp(app.x_d, u)
+	for (i, κ_x) ∈ enumerate(app.κ), (j, κ_y) ∈ enumerate(app.κ)
+		κ[i, j, 1] = κ_x
+		κ[i, j, 2] = κ_y
+	end
+	@views κx, κy = κ[:, :, 1], κ[:, :, 2]
+	û = app.P̂ * u
+	out = @. 1.0im * κx * û[:, :, 1] + 1.0im * κy * û[:, :, 2]
+	return real(ifft(out))
+end
+
+function ∇X(app::KFlowApp, V)
+	κ = get_tmp(app.x_d, V)
+	for (i, κ_x) ∈ enumerate(app.κ), (j, κ_y) ∈ enumerate(app.κ)
+		κ[i, j, 1] = κ_x
+		κ[i, j, 2] = κ_y
+	end
+	f = get_tmp(app.ϕ_d, V)
+	V̂ = app.P̂ * V
+	@views V̂x, V̂y = V̂[:, :, 1], V̂[:, :, 2]
+	@views κx, κy = κ[:, :, 1], κ[:, :, 2]
+	out = @. 1.0im * κx * V̂y - 1.0im * κy * V̂x
+	return real(ifft(out))
+end
+
+function spectralInterpolation(f, targetSize)
+	size_f = size(f)[1] # assume square
+	targetSize > size_f || return f
+	npad = floor(Int, targetSize / 2 - size_f / 2)
+	f̂ = fftshift(fft(f))
+	C = eltype(f̂)
+	f̂_interp = [
+		zeros(C, npad, npad)   zeros(C, npad, size_f) zeros(C, npad, npad)
+		zeros(C, size_f, npad) f̂           zeros(C, size_f, npad)
+		zeros(C, npad, npad)   zeros(C, npad, size_f) zeros(C, npad, npad)
+	]
+	return real(ifft(ifftshift(f̂_interp)))
+end
+
+function base_step!(app::KFlowApp, u::AbstractArray, Δt::Float)
+	kolmogorovForce!(app, u, Δt)
+	advect_semi_lagrangian!(app, u, u, Δt)
+	project_incompressible!(app, u, Δt)
+	return u
+end
+
+function my_init(app::KFlowApp, t::Float)
+	seed!(1)
+	# u = zeros(Float, nₓ, nₓ, 2)
+	u = randn(Float, nₓ, nₓ, 2)
+	# TaylorGreen!(app, u)
+	project_incompressible!(app, u, 1e-1app.ℜ)
+	u[:, :, 1] .-= mean(u[:, :, 1])
+	u[:, :, 2] .-= mean(u[:, :, 2])
+	u ./= my_norm(app, u)
+	return u
+end
+
+function my_basis_init(app::KFlowApp, t::Float, i::Integer)
+	ψ = zeros(Float, nₓ, nₓ, 2)
+	fourierMode2DVec!(app, ψ, i + 1)
+	return ψ
+end
+
+function my_step!(
+	app::KFlowApp, status::Ptr{Cvoid},
+	u::AbstractArray, ustop::AbstractArray,
+	tstart::Real, tstop::Real,
+)
+	Δt = tstop - tstart
+	level = XBraid.status_GetLevel(status)
+	iter = XBraid.status_GetIter(status)
+	if !app.useTheta || level == 0
+		u = base_step!(app, u, Δt)
+	else
+		# richardson based θ method
+		m = app.cf ^ level
+		p = 1
+		θ = 2^p * (m^p - 1) / (m^p * (2^p - 1))
+		# θ = 2
+		u_sub = deepcopy(u)
+		base_step!(app, u_sub, Δt / 2)
+		base_step!(app, u_sub, Δt / 2)
+		base_step!(app, u, Δt)
+		@. u = θ * u_sub + (1 - θ) * u
+	end
+	return u
+end
+
+function my_step!(
+	app::KFlowApp, status::Ptr{Cvoid},
+	u::AbstractArray, ustop::AbstractArray,
+	tstart::Real, tstop::Real,
+	Ψ::Vector{Any}
+)
+	rank = length(Ψ)
+	Ψ_new = reduce((a, b) -> cat(a, b, dims = 4), Ψ)
+	perturb(r) = my_step!(app, status, u + r' * Ψ, ustop, tstart, tstop)
+
+	result = DiffResults.DiffResult(u, Ψ_new)
+	result = ForwardDiff.jacobian!(result, perturb, zeros(rank))
+	for i in 1:rank
+		Ψ[i] .= Ψ_new[:, :, :, i]
+	end
+	return
+end
+
+function my_sum!(app, a, x, b, y)
+	@. y = a * x + b * y
+end
+
+function my_access(app::KFlowApp, status, u)
+	XBraid.status_GetWrapperTest(status) && return
+	ntime = XBraid.status_GetNTPoints(status)
+	index = XBraid.status_GetTIndex(status)
+	level, done = XBraid.status_GetLevel(status), XBraid.status_GetDone(status)
+
+	if level == 0 && done && index % app.cf == 0
+		push!(app.solution, deepcopy(u))
+		push!(app.times, index)
+		rank = XBraid.status_GetDeltaRank(status)
+		if rank > 0
+			exps = XBraid.status_GetLocalLyapExponents(status)
+			vecs = XBraid.status_GetBasisVectors(status)
+			push!(app.lyapunov_exps, exps)
+			push!(app.lyapunov_vecs, deepcopy(vecs))
+		end
+	end
+
+	if level == 0 && index == ntime-1
+		# last time step
+		push!(app.solTf, deepcopy(u))
+	end
+end
+
+my_norm(app, u) = LinearAlgebra.normInf(u)
+my_innerprod(app, u, v) = u ⋅ v
+
+const lengthScale = 2π
+const nₓ = 99
+const Δx = lengthScale / nₓ
+
+function test()
+	my_app = KFlowApp(2, false, 3, 2, 1600)
+
+	test_app = XBraid.BraidApp(
+		my_app, comm, comm,
+		my_step!, my_init,
+		my_sum!, my_norm, my_access,
+		my_basis_init, my_innerprod)
+
+	XBraid.testInitAccess(test_app, 0.0)
+	XBraid.testClone(test_app, 0.0)
+	XBraid.testSpatialNorm(test_app, 0.0)
+	XBraid.testBuf(test_app, 0.0)
+	XBraid.testDelta(test_app, 0.0, 0.1, my_app.deltaRank)
+
+	# curl = ∇X(my_app, my_app.solution[1])
+	# heatmap(curl')
+end
+
+function main(;tstop=20.0, ntime=512, deltaRank=0, ml=1, cf=2, maxiter=10, fcf=1, relaxLyap=false, savegif=false, useTheta=false, k=4, ℜ=1600, deferDelta=(1, 1))
+	my_app = KFlowApp(cf, useTheta, deltaRank, k, ℜ)
+
+	tstart = 0.0
+
+	core = XBraid.Init(
+		comm, comm, tstart, tstop, ntime,
+		my_step!, my_init, my_sum!, my_norm, my_access; app = my_app,
+	)
+
+	if deltaRank > 0
+		XBraid.SetDeltaCorrection(core, deltaRank, my_basis_init, my_innerprod)
+		# XBraid.SetDeferDelta(core, deferDelta...)
+		XBraid.SetLyapunovEstimation(core; relax = relaxLyap, exponents = true)
+	end
+	XBraid.SetMaxLevels(core, ml)
+	XBraid.SetMaxIter(core, maxiter)
+	XBraid.SetCFactor(core, -1, cf)
+	XBraid.SetNRelax(core, -1, fcf)
+	XBraid.SetAccessLevel(core, 2)
+	XBraid.SetAbsTol(core, 1e-6)
+
+	XBraid.SetTimings(core, 2)
+	XBraid.Drive(core)
+	XBraid.PrintTimers(core)
+
+	p = sortperm(my_app.times)
+
+	if deltaRank > 0
+	    exponents = sum(my_app.lyapunov_exps)
+	    exponents = MPI.Allreduce(exponents, (+), comm)
+	    exponents ./= tstop - tstart
+	    if MPI.Comm_rank(comm) == 0
+	        println("exponents: ", exponents)
+	    end
+	end
+
+	# if deltaRank > 0
+	# 	movingaverage(g, n) = [i < n ? mean(g[begin:i]) : mean(g[i-n+1:i]) for i in eachindex(g)]
+	# 	println("Lyap Exps: ", sum(my_app.lyapunov_exps) ./ tstop)
+	# 	exps = reduce(hcat, my_app.lyapunov_exps[p])'
+	# 	nt = size(exps)[1]
+	# 	Δt = tstop / nt
+	# 	exps = movingaverage.([exps[:, i] ./ Δt for i ∈ 1:size(exps)[2]], length(exps[:, 1]))
+	# 	exps_plot = plot(exps; legend = false)
+	# 	savefig(exps_plot, "lyapunov_exps.png")
+	# end
+
+	if savegif
+		preprocess(app, u) = spectralInterpolation(∇X(app, u), 128)'
+		heatmapArgs = Dict(:ticks => false, :colorbar => false, :aspect_ratio => :equal)
+		# anim = @animate for i in p[1:cf:end]
+		count = 1
+		for i in p
+			u = my_app.solution[i]
+			plots = [heatmap(preprocess(my_app, u); heatmapArgs...)]
+			for j in 1:min(8, deltaRank)
+				ψⱼ = my_app.lyapunov_vecs[i][j]
+				push!(plots, heatmap(preprocess(my_app, ψⱼ); heatmapArgs...))
+			end
+			fig = plot(plots...; size = (600, 600))
+			savefig(fig, "kflow_gif/beamer/kolmo_$(nₓ)_$(ntime)_ml$(ml)-$(count).png")
+			count += 1
+		end
+		# gif(anim, "kflow_gif/kolmo_$(nₓ)_$(ntime)_ml$(ml).gif", fps = 20)
+	end
+
+
+	return my_app, core
+end

--- a/examples/julia/ex-01.jl
+++ b/examples/julia/ex-01.jl
@@ -1,0 +1,69 @@
+# main ex-01
+# include("XBraid.jl")
+include("../../braid/braid.jl/XBraid.jl")
+using .XBraid
+using MPI
+
+MPI.Init()
+comm = MPI.COMM_WORLD
+
+#=
+using 1-element vector here since standard Float64
+values are immutable and don't have stable addresses.
+=#
+function my_init(app, t)
+    t == 0.0 && return [1.0]
+    return [0.456]
+end
+
+# This must mutate u in place
+function my_step!(app, status, u, ustop, tstart, tstop)
+    # backward Euler
+    u[] = 1.0 / (1.0 + tstop - tstart) * u[]
+end
+
+#=
+called by the solver to give access to 
+solution values.
+=#
+function my_access(app, status, u)
+    XBraid.status_GetWrapperTest(status) && return
+    t = XBraid.status_GetT(status)
+    ti = XBraid.status_GetTIndex(status)
+    print("t: $(t[]),\tu: $(u[])\n")
+end
+
+#=
+all other usual wrapper functions are either not required, 
+or are set to reasonable defaults for operating on julia Arrays. 😎
+=#
+
+test = false
+if test
+    test_app = XBraid.BraidApp(nothing, comm, my_step!, my_init, my_access)
+
+    open("ex_01.test.out", "w") do file
+        cfile = Libc.FILE(file)
+        XBraid.testInitAccess(test_app, 0.0, cfile)
+        XBraid.testClone(test_app, 0.0, cfile)
+        XBraid.testSum(test_app, 0.0, cfile)
+        XBraid.testSpatialNorm(test_app, 0.0, cfile)
+        XBraid.testBuf(test_app, 0.0, cfile)
+    end
+    MPI.Barrier(comm)
+end
+
+ntime = 10
+tstart = 0.0
+tstop = tstart + ntime / 2.0;
+core = XBraid.Init(comm, tstart, tstop, ntime, my_step!, my_init, my_access)
+
+XBraid.SetPrintLevel(core, 2)
+XBraid.SetMaxLevels(core, 2)
+XBraid.SetAbsTol(core, 1.e-6)
+XBraid.SetCFactor(core, -1, 2)
+
+XBraid.Drive(core)
+
+# no need for braid_Destroy(core), julia will take care of it :)
+MPI.Finalize()

--- a/makefile.inc
+++ b/makefile.inc
@@ -22,10 +22,11 @@
 #
 #EHEADER**********************************************************************
 
-# Three compile time options
+# four compile time options
 # make debug=yes|no
 # make valgrind=yes|no
 # make sequential=yes|no
+# make shared=yes|no
 
 # Was DEBUG specified? 
 ifeq ($(debug),no)
@@ -60,6 +61,7 @@ ifeq ($(findstring tux408,$(HOSTNAME)),tux408)
    MPICXX = mpicxx
    MPIF90 = mpif90
    LFLAGS = -lm
+   SHAREDFLAGS = -shared
    ifeq ($(optlevel),DEBUG)
       CFLAGS = -g -Wall -lm -fPIC
       CXXFLAGS = -g -Wall -Wno-reorder -lm -fPIC
@@ -80,6 +82,7 @@ else ifeq ($(shell uname -s), Darwin)
    MPICXX = mpicxx
    MPIF90 = mpif90
    LFLAGS = -lm -lstdc++
+   SHAREDFLAGS = -shared -undefined dynamic_lookup
    ifeq ($(optlevel),DEBUG)
       CFLAGS = -g -Wall -fPIC
       CXXFLAGS = -g -Wall -fPIC
@@ -95,6 +98,7 @@ else ifeq ($(findstring cab,$(HOSTNAME)),cab)
    MPICXX = mpiicpc
    MPIF90 = mpif90
    LFLAGS = -lm
+   SHAREDFLAGS = -shared
    ifeq ($(optlevel),DEBUG)
       CFLAGS = -g -Wall -fPIC
       CXXFLAGS = -g -Wall -fPIC
@@ -110,6 +114,7 @@ else ifeq ($(findstring vulcan,$(HOSTNAME)),vulcan)
    MPICXX = mpixlcxx
    MPIF90 = mpixlf90
    LFLAGS = -lm
+   SHAREDFLAGS = -shared
    ifeq ($(optlevel),DEBUG)
       CFLAGS = -g -Wall -fPIC
       CXXFLAGS = -g -Wall -fPIC
@@ -126,6 +131,7 @@ else ifeq ($(findstring cadaverous,$(HOSTNAME)),cadaverous)
    MPICXX = /usr/bin/mpicxx
    MPIF90 = /usr/bin/mpif90
    LFLAGS = -lm
+   SHAREDFLAGS = -shared
    ifeq ($(optlevel),DEBUG)
       CFLAGS = -g -Wall -fPIC
       CXXFLAGS = -g -Wall -fPIC
@@ -140,6 +146,7 @@ else ifeq ($(shell uname -s),Linux)
    MPICXX = mpicxx
    MPIF90 = mpif90
    LFLAGS = -lm
+   SHAREDFLAGS = -shared
    ifeq ($(optlevel),DEBUG)
       CFLAGS = -g -Wall -fPIC
       CXXFLAGS = -g -Wall -fPIC
@@ -157,6 +164,7 @@ else
    MPICXX = mpicxx
    MPIF90 = mpif90
    LFLAGS = -lm
+   SHAREDFLAGS = -shared
    ifeq ($(optlevel),DEBUG)
       CFLAGS = -g -Wall -fPIC
       CXXFLAGS = -g -Wall -fPIC
@@ -174,6 +182,7 @@ ifeq ($(sequential),YES)
    MPICXX = g++
    MPIF90 = gfortran
    LFLAGS = -lm
+   SHAREDFLAGS = -shared
    ifeq ($(optlevel),DEBUG)
       CFLAGS = -g -Wall -D braid_SEQUENTIAL
       CXXFLAGS = -g -Wall -D braid_SEQUENTIAL


### PR DESCRIPTION
(reopening on new branch)

Introduces a new interface to XBraid, written in Julia, along with an example and a couple of drivers demonstrating the usage of the interface.

I originally did not intend to make a pull request for this, as I made it for my own personal use, so I have made some choices that may be too restrictive. I have made this a draft pr so we can discuss the choices made.

My goal was to write the interface so that the user does not have to manage any memory or communication, and as a result the user does not write clone, free, bufpack, or bufunpack routines, and some default functions are provided for sum, norm, and inner_prod, assuming the user's vector is a Julia array.

Julia also being a just-in-time compiled language resulted in the need for a "warmup" function, which allows the user's functions to be compiled before braid_Drive is called. Without this, if the first downcycle is skipped, the user's step function is compiled every time it is called on the coarse grid by a new processor, which adds a lot of extra serial work to the first iteration.

notable features missing:

    XBraid adjoint
    spatial coarsening/refinement
    residual option
    sync function

I believe all of these features are fairly straightforward to implement, I just haven't had a need to work on them.
