### PR TITLE
Adds braid_StatusGetCFactor

### DIFF
--- a/braid/braid_status.c
+++ b/braid/braid_status.c
@@ -115,6 +115,26 @@ braid_StatusGetLevel(braid_Status status,
 }
 
 braid_Int
+braid_StatusGetCFactor(braid_Status status,
+                       braid_Int   *cfactor_ptr,
+                       braid_Int    level
+                       )
+{
+   _braid_Grid **grids  = _braid_StatusElt(status, grids);
+   braid_Int    nlevels = _braid_StatusElt(status, nlevels);
+
+   if (level < 0 || level >= nlevels)
+   {
+      *cfactor_ptr = -1;
+   }
+   else
+   {
+      *cfactor_ptr = _braid_GridElt(grids[level], cfactor);
+      return _braid_error_flag;
+   }
+}
+
+braid_Int
 braid_StatusGetNLevels(braid_Status status,
                        braid_Int   *nlevels_ptr
                        )
@@ -251,13 +271,11 @@ braid_StatusGetBasisVec(braid_Status  status,
                         )
 {
    braid_Basis ba = _braid_StatusElt(status, lvectors);
+
+   *v_ptr = NULL;
    if ((ba != NULL) && (index < ba->rank))
    {
       *v_ptr = ba->userVecs[index];
-   }
-   else // gracefully return NULL
-   {
-      v_ptr = NULL;
    }
    return _braid_error_flag;
 }
@@ -721,6 +739,7 @@ ACCESSOR_FUNCTION_GET1(Access, CallingFunction,       Int)
 ACCESSOR_FUNCTION_GET1(Access, SingleErrorEstAccess,  Real)
 ACCESSOR_FUNCTION_GET1(Access, DeltaRank,             Int)
 ACCESSOR_FUNCTION_GET2(Access, LocalLyapExponents,    Real, Int)
+ACCESSOR_FUNCTION_GET1_IN1(Access, CFactor,           Int, Int)
 ACCESSOR_FUNCTION_GET1_IN1(Access, BasisVec,          Vector, Int)
 
 /*--------------------------------------------------------------------------
@@ -852,6 +871,7 @@ ACCESSOR_FUNCTION_GET1(Step, Done,                 Int)
 ACCESSOR_FUNCTION_GET1(Step, SingleErrorEstStep,   Real)
 ACCESSOR_FUNCTION_GET1(Step, CallingFunction,      Int)
 ACCESSOR_FUNCTION_GET1(Step, DeltaRank,            Int)
+ACCESSOR_FUNCTION_GET1_IN1(Step, CFactor,          Int, Int)
 ACCESSOR_FUNCTION_GET1_IN1(Step, BasisVec,         Vector, Int)
 
 /*--------------------------------------------------------------------------

--- a/braid/braid_status.c
+++ b/braid/braid_status.c
@@ -123,15 +123,15 @@ braid_StatusGetCFactor(braid_Status status,
    _braid_Grid **grids  = _braid_StatusElt(status, grids);
    braid_Int    nlevels = _braid_StatusElt(status, nlevels);
 
-   if (level < 0 || level >= nlevels)
+   if (level < 0 || level >= (nlevels-1))
    {
       *cfactor_ptr = -1;
    }
    else
    {
       *cfactor_ptr = _braid_GridElt(grids[level], cfactor);
-      return _braid_error_flag;
    }
+   return _braid_error_flag;
 }
 
 braid_Int

--- a/braid/braid_status.h
+++ b/braid/braid_status.h
@@ -184,6 +184,14 @@ braid_Int
 braid_StatusGetLevel(braid_Status status,                  /**< structure containing current simulation info */
                      braid_Int   *level_ptr                /**< output, current level in XBraid */
                      );
+/**
+ * Return the coarsening factor on the given level from the Status structure.
+ **/
+braid_Int
+braid_StatusGetCFactor(braid_Status status,                /**< structure containing current simulation info */
+                       braid_Int   *cfactor_ptr,           /**< output, coarsening factor on current level */
+                       braid_Int    level                  /**< level to get coarsening factor for */
+                       );
 
 /**
  * Return the total number of XBraid levels from the Status structure.
@@ -626,6 +634,7 @@ ACCESSOR_HEADER_GET1(Access, CallingFunction, Int)
 ACCESSOR_HEADER_GET1(Access, SingleErrorEstAccess, Real)
 ACCESSOR_HEADER_GET1(Access, DeltaRank, Int)
 ACCESSOR_HEADER_GET2(Access, LocalLyapExponents, Real, Int)
+ACCESSOR_HEADER_GET1_IN1(Access, CFactor,  Int, Int)
 ACCESSOR_HEADER_GET1_IN1(Access, BasisVec, Vector, Int)
 
 /*--------------------------------------------------------------------------
@@ -688,6 +697,7 @@ ACCESSOR_HEADER_GET1(Step, Done,               Int)
 ACCESSOR_HEADER_GET1(Step, SingleErrorEstStep, Real)
 ACCESSOR_HEADER_GET1(Step, CallingFunction,    Int)
 ACCESSOR_HEADER_GET1(Step, DeltaRank,          Int)
+ACCESSOR_HEADER_GET1_IN1(Step, CFactor,        Int, Int)
 ACCESSOR_HEADER_GET1_IN1(Step, BasisVec,       Vector, Int)
 
 /*--------------------------------------------------------------------------
@@ -754,6 +764,8 @@ ACCESSOR_HEADER_GET1(Objective, Tol,           Real)
 #define braid_ASCaller_Residual 11
 /** When CallingFunction equals 12, Braid is in InitGuess */
 #define braid_ASCaller_InitGuess 12
+/** When CallingFunction equals 13, Braid is in Warmup */
+#define braid_ASCaller_Warmup 13
 
 /** @}*/
 


### PR DESCRIPTION
braid_StatusGetCFactor(braid_Status status, braid_Int *cfactor_ptr, braid_Int level) for StepStatus and AccessStatus
- returns cfactor on given level
- along with small bugfix for braid_StatusGetBasisVec
I know in the past this has been achieved by storing the cfactor for each level in an array in braid_App, but I find this is annoying every time I have to do it, especially when this information is already stored in `core->grids`.
This is especially useful for my theta method implementation with adaptive refinement.