### PR TITLE
adding new feature that allows the user to turn off the global residu…

### DIFF
--- a/braid/_braid.h
+++ b/braid/_braid.h
@@ -292,6 +292,7 @@ typedef struct _braid_Core_struct
 
    braid_Int              access_level;     /**< determines how often to call the user's access routine */ 
    braid_Int              finalFCrelax;     /**< determines if a final FCrelax is performed (default 0=false) */ 
+   braid_Int              resid_compute;    /**< determines if the global residual norm is computed (default 1=true) */
    braid_Int              print_level;      /**< determines amount of output printed to screen (0,1,2,3) */
    braid_Int              io_level;         /**< determines amount of output printed to files (0,1) */
    braid_Int              seq_soln;         /**< boolean, controls if the initial guess is from sequential time stepping*/

--- a/braid/braid.c
+++ b/braid/braid.c
@@ -236,6 +236,7 @@ braid_Init(MPI_Comm               comm_world,
    braid_Int              io_level         = 1;              /* Default output-to-file level */
    braid_Int              access_level     = 1;              /* Default access level */
    braid_Int              finalFCrelax     = 0;              /* Default final FCrelax */
+   braid_Int              resid_compute    = 1;              /* Default computes and outputs the residual norm each iteration */
    braid_Int              tnorm            = 2;              /* Default temporal norm */
    braid_Real             tol              = 1.0e-09;        /* Default absolute tolerance */
    braid_Int              warm_restart     = 0;              /* Default is no warm restart */
@@ -298,6 +299,7 @@ braid_Init(MPI_Comm               comm_world,
 
    _braid_CoreElt(core, access_level)    = access_level;
    _braid_CoreElt(core, finalFCrelax)    = finalFCrelax;
+   _braid_CoreElt(core, resid_compute)   = resid_compute;
    _braid_CoreElt(core, tnorm)           = tnorm;
    _braid_CoreElt(core, print_level)     = print_level;
    _braid_CoreElt(core, io_level)        = io_level;
@@ -617,6 +619,7 @@ braid_PrintStats(braid_Core  core)
    braid_PtFcnResidual fullres = _braid_CoreElt(core, full_rnorm_res);
    _braid_Grid **grids         = _braid_CoreElt(core, grids);
    braid_Int     finalFCRelax  = _braid_CoreElt(core, finalFCrelax);
+   braid_Int     resid_compute = _braid_CoreElt(core, resid_compute);
    braid_Int     periodic      = _braid_CoreElt(core, periodic);
    braid_Int     adjoint       = _braid_CoreElt(core, adjoint);
    braid_Int     timings       = _braid_CoreElt(core, timings);
@@ -709,6 +712,7 @@ braid_PrintStats(braid_Core  core)
       _braid_printf("  periodic              = %d\n", periodic);
       _braid_printf("  relax_only_cg         = %d\n", relax_only_cg);
       _braid_printf("  finalFCRelax          = %d\n", finalFCRelax);
+      _braid_printf("  resid_compute         = %d\n", resid_compute);
       _braid_printf("  tracking timings      = %d\n", timings);
       _braid_printf("  number of refinements = %d\n", nrefine);
       _braid_printf("\n");
@@ -1079,6 +1083,18 @@ braid_SetFinalFCRelax(braid_Core core)
    _braid_CoreElt(core, finalFCrelax) = 1;
    return _braid_error_flag;
 }
+
+/*--------------------------------------------------------------------------
+ *--------------------------------------------------------------------------*/
+
+braid_Int
+braid_SetResidualComputation(braid_Core  core,
+                             braid_Int   resid_compute)
+{
+   _braid_CoreElt(core, resid_compute) = resid_compute;
+   return _braid_error_flag;
+}
+
 
 /*--------------------------------------------------------------------------
  *--------------------------------------------------------------------------*/

--- a/braid/braid.h
+++ b/braid/braid.h
@@ -963,6 +963,27 @@ braid_Int
 braid_SetFinalFCRelax(braid_Core core);
 
 /**
+ * Set residual computation for XBraid.  This controls whether the global
+ * residual norm is computed each iteration.  Turning off the global residual
+ * norm computation (a value of 0) saves one global MPI all-reduce each
+ * iteration.
+ *
+ * Turning off this computation (value of 0) means that XBraid will iterate
+ * until the maximum number of iterations is reached. However, if the number of
+ * iterations is known a-priori, the MPI cost saving can be beneficial. Note that
+ * the level of printed Braid output (which controls whether the global
+ * residual norm is printed) is controlled by (@ref braid_SetPrintLevel).
+ *
+ * Options
+ * 0:  Never compute the global residual norm
+ * 1:  Every iteration, compute the global residual norm
+ **/
+braid_Int
+braid_SetResidualComputation(braid_Core  core,           /**< braid_Core (_braid_Core) struct*/
+                             braid_Int   resid_compute   /**< desired resid_compute option */
+                             );
+
+/**
  * Set user-defined allocation and free routines for the MPI buffer. If these 
  * routines are not set, the default is to malloc and free with standard C.
  **/

--- a/examples/ex-01-expanded.c
+++ b/examples/ex-01-expanded.c
@@ -413,6 +413,7 @@ int main (int argc, char *argv[])
    int           periodic      = 0;
    int           relax_only_cg = 0;
    int           bufalloc      = 0;
+   int           resid_compute = 1;
 
    int           arg_index;
    int           rank;
@@ -445,6 +446,7 @@ int main (int argc, char *argv[])
             printf("  -cf  <cfactor>    : set coarsening factor\n");
             printf("  -mi  <max_iter>   : set max iterations\n");
             printf("  -skip <set_skip>  : set skip relaxations on first down-cycle; 0: no skip;  1: skip\n");
+            printf("  -resid_compute    : set global residual norm computation; 0: none; 1: compute global norm each iter\n");
             printf("  -timings <bool>   : turn XBraid internal timings on/off\n");
             printf("  -fmg              : use FMG cycling\n");
             printf("  -res              : use my residual\n");
@@ -543,6 +545,11 @@ int main (int argc, char *argv[])
          arg_index++;
          skip = atoi(argv[arg_index++]);
       }
+      else if ( strcmp(argv[arg_index], "-resid_compute") == 0 )
+      {
+         arg_index++;
+         resid_compute = atoi(argv[arg_index++]);
+      }
       else
       {
          arg_index++;
@@ -578,6 +585,7 @@ int main (int argc, char *argv[])
    braid_SetMaxIter(core, max_iter);
    braid_SetTimings(core, timings);
    braid_SetSkip(core, skip);
+   braid_SetResidualComputation(core, resid_compute);
    if (fmg)
    {
       braid_SetFMG(core);

--- a/test/ode1D.saved
+++ b/test/ode1D.saved
@@ -245,3 +245,17 @@ Finished braid_TestAll: no fails detected, however some results must be
   max number of levels  = 3
   number of levels      = 3
   tracking timings      = 1
+# Begin Test 36
+  time steps = 10
+  iterations            = 6
+  residual norm         = -1.000000e+00
+  max number of levels  = 2
+  number of levels      = 2
+  tracking timings      = 0
+# Begin Test 37
+  time steps = 10
+  iterations            = 4
+  residual norm         = 0.000000e+00
+  max number of levels  = 2
+  number of levels      = 2
+  tracking timings      = 0

--- a/test/ode1D.sh
+++ b/test/ode1D.sh
@@ -127,7 +127,9 @@ TESTS=( "$RunString -np 1 $example_dir/ex-01" \
         "$RunString -np 2 $example_dir/ex-01-expanded -ntime 48 -ml 3 -mi 3 -cf 2 -bufalloc" \
         "$RunString -np 3 $example_dir/ex-01-expanded -ntime 48 -ml 3 -mi 3 -cf 2 -bufalloc" \
         "$RunString -np 1 $example_dir/ex-01-expanded -ml 3 -mi 3 -timings 0" \
-        "$RunString -np 3 $example_dir/ex-01-expanded -ml 3 -mi 3 -timings 1" )
+        "$RunString -np 3 $example_dir/ex-01-expanded -ml 3 -mi 3 -timings 1" \
+        "$RunString -np 3 $example_dir/ex-01-expanded -mi 6 -resid_compute 0" \
+        "$RunString -np 3 $example_dir/ex-01-expanded -mi 6 -resid_compute 1" )
 
 # The below commands will then dump each of the tests to the output files 
 #   $output_dir/unfiltered.std.out.0, 


### PR DESCRIPTION
@rfalgout  @eric-c-cyr

Hi Guys -- the TorchBraid folks have been asking for an easy way to turn off the global MPI Allreduce during the residual norm computation.  We usually have a fixed number of iterations, so this Allreduce is just extra work.  It turns out if we can turn off this Allreduce, it actually saves a decent amount of time in the GPU-MPI setting.

Take a look and let me know -- Thanks!